### PR TITLE
Добавлен пример проверки адреса возврата для статических методов.

### DIFF
--- a/ArtemisComponents/Arthemida-2/API/ArtemisInterface.h
+++ b/ArtemisComponents/Arthemida-2/API/ArtemisInterface.h
@@ -21,6 +21,7 @@ namespace ARTEMIS_INTERFACE
 		static IArtemisInterface* __stdcall InstallArtemisMonitor(ArtemisConfig* cfg);
 		static IArtemisInterface* __stdcall GetInstance();
 		static ArtemisConfig* __stdcall GetConfig();
+		void __thiscall ConfirmLegitReturn(const char* function_name, PVOID return_address);
 	protected:
 		virtual ~IArtemisInterface() = default;
 		static IArtemisInterface* CreateInstance(ArtemisConfig* cfg); 

--- a/ArtemisComponents/Arthemida-2/API/ArtemisTypes.h
+++ b/ArtemisComponents/Arthemida-2/API/ArtemisTypes.h
@@ -67,7 +67,8 @@ namespace ArtemisData
 		std::vector<PVOID> ExcludedMethods;
 		std::vector<PVOID> ExcludedPatches;
 		std::vector<PVOID> ExcludedSigAddresses;
-		std::map<PVOID, PVOID> HooksList; // DestinyAddress, HookAddress
+		std::map<PVOID, PVOID> HooksList; // DestinyAddress, InterceptorAddress
+		//std::map<PVOID, bool> ProtectedFunctions; // DestinyAddress, Detection flag
 		std::map<std::string, std::tuple<const char*, const char*>> IllegalPatterns; // hack name, pattern, mask
 	};
 }

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj
@@ -167,6 +167,7 @@
     <ClInclude Include="..\..\Arthemida-2\ArtModules\HeuristicScanner.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtModules\ThreadScanner.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\CRC32.h" />
+    <ClInclude Include="..\..\Arthemida-2\ArtUtils\MiniJumper.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\sigscan.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\SString.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\SString.hpp" />

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj.filters
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj.filters
@@ -80,5 +80,8 @@
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\SString.hpp">
       <Filter>Arthemida-2\ArtUtils</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Arthemida-2\ArtUtils\MiniJumper.h">
+      <Filter>Arthemida-2\ArtUtils</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
В связующий интерфейс Артемиды, добавлен публичный метод для проверок адресов возвратов с любых функций вручную, вместо гемороя с установками хуков как это было в предыдущей версии античита.