### PR TITLE
1. Убран баг с неправильным получением размера в GetModuleMemoryInfo …

### DIFF
--- a/ArtemisComponents/Arthemida-2/ArtModules/AntiFakeLaunch.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/AntiFakeLaunch.h
@@ -13,7 +13,7 @@ void __stdcall ConfirmLegitLaunch(ArtemisConfig* cfg)
 		return;
 	}
 #ifdef ARTEMIS_DEBUG
-	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for CheckLauncher!\n");
+	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for CheckLauncher! Thread id: %d\n", GetCurrentThreadId());
 #endif
 	decltype(auto) AttemptAboveIt = [&]() -> void
 	{

--- a/ArtemisComponents/Arthemida-2/ArtModules/CServiceMon.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/CServiceMon.h
@@ -33,7 +33,8 @@ private:
 void CServiceMon::MonitorCycle()
 {
 #ifdef ARTEMIS_DEBUG
-    Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for CServiceMon::MonitorCycle!\n");
+    Utils::LogInFile(ARTEMIS_LOG, 
+    "[INFO] Created async thread for CServiceMon::MonitorCycle! Thread id: %d\n", GetCurrentThreadId());
 #endif
     static bool RUN = false; // ! DEBUG - ONE TIME RUN
     std::multimap<std::wstring, SServiceInfo> mmServices;

--- a/ArtemisComponents/Arthemida-2/ArtModules/HeuristicScanner.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/HeuristicScanner.h
@@ -4,7 +4,7 @@
 	Project by NtKernelMC & holmes0
 */
 #include "ArtemisInterface.h"
-void __stdcall SigScanner(ArtemisConfig* cfg) // CAUTION! Not tested yet.
+void __stdcall SigScanner(ArtemisConfig* cfg) // CAUTION! Still remaining on development.
 {
 	if (cfg == nullptr)
 	{
@@ -14,7 +14,7 @@ void __stdcall SigScanner(ArtemisConfig* cfg) // CAUTION! Not tested yet.
 		return;
 	}
 #ifdef ARTEMIS_DEBUG
-	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for SigScanner!\n");
+	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for SigScanner! Thread id: %d\n", GetCurrentThreadId());
 #endif
 	if (cfg->IllegalPatterns.empty())
 	{
@@ -29,7 +29,7 @@ void __stdcall SigScanner(ArtemisConfig* cfg) // CAUTION! Not tested yet.
 	{
 		for (const auto& KeyValuePair : cfg->IllegalPatterns)
 		{
-			for (const auto& it : orderedMapping)
+			/*for (const auto& it : orderedMapping)
 			{
 				if (it.first == (DWORD)GetModuleHandleA("kernel32.dll")) continue;
 				DWORD scanAddr = SigScan::FindPatternExplicit((DWORD)it.first, it.second,
@@ -45,7 +45,7 @@ void __stdcall SigScanner(ArtemisConfig* cfg) // CAUTION! Not tested yet.
 					data.HackName = KeyValuePair.first; data.type = DetectionType::ART_SIGNATURE_DETECT;
 					cfg->callback(&data); cfg->ExcludedSigAddresses.push_back((PVOID)it.first);
 				}
-			}
+			}*/
 		}
 		Sleep(cfg->PatternScanDelay);
 	}

--- a/ArtemisComponents/Arthemida-2/ArtModules/MemoryGuard.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/MemoryGuard.h
@@ -43,7 +43,7 @@ void __stdcall MemoryGuardScanner(ArtemisConfig* cfg) // On tehnical work
 		return;
 	}
 #ifdef ARTEMIS_DEBUG
-	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for MemoryGuardScanner!\n");
+	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for MemoryGuardScanner! Thread id: %d\n", GetCurrentThreadId());
 #endif
 	auto ReverseDelta = [](DWORD_PTR CurrentAddress, DWORD Delta, size_t InstructionLength, bool bigger = false) -> DWORD_PTR
 	{

--- a/ArtemisComponents/Arthemida-2/ArtModules/MemoryScanner.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/MemoryScanner.h
@@ -14,7 +14,7 @@ void __stdcall MemoryScanner(ArtemisConfig* cfg)
 		return;
 	}
 #ifdef ARTEMIS_DEBUG
-	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for MemoryScanner!\n");
+	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for MemoryScanner! Thread id: %d\n", GetCurrentThreadId());
 #endif
 	while (true)
 	{

--- a/ArtemisComponents/Arthemida-2/ArtModules/ModuleScanner.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/ModuleScanner.h
@@ -11,11 +11,13 @@ struct SLibVersionInfo : VS_FIXEDFILEINFO
 	MtaUtils::SString strCompanyName;
 	MtaUtils::SString strProductName;
 }; 
+// Will be changed in next update, detected kernelbase recursive calls with highload perfomance!
+// Issued WIN API: GetFileVersionInfoSizeA - There no way i guess to use it in scan cycle, always called FreeLibrary.
 static bool GetLibVersionInfo(const MtaUtils::SString& strLibName, SLibVersionInfo* pOutLibVersionInfo)
 {
 	DWORD dwHandle = 0x0, dwLen = 0x0;
 	dwLen = GetFileVersionInfoSizeA(strLibName, &dwHandle);
-	if (!dwLen) return FALSE;
+	if (!dwLen) return false;
 	LPTSTR lpData = (LPTSTR)malloc(dwLen);
 	if (!lpData) return FALSE; SetLastError(0);
 	if (!GetFileVersionInfoA(strLibName, NULL, dwLen, lpData))
@@ -51,29 +53,32 @@ static bool GetLibVersionInfo(const MtaUtils::SString& strLibName, SLibVersionIn
 }
 typedef NTSTATUS(__stdcall* ptrLdrUnloadDll)(HMODULE ModuleHandle);
 ptrLdrUnloadDll callLdrUnloadDll = nullptr;
-NTSTATUS __stdcall LdrUnloadDll(HMODULE ModuleHandle)
+void __stdcall LdrUnloadDll(HMODULE ModuleHandle) // For now - all hooks are in the code-refactoring
 {
-	if (ModuleHandle == nullptr) return ERROR_FILE_NOT_FOUND;
-	NTSTATUS rslt = NULL; // CodeAnalyzer : Var Init Rule 
-	if (callLdrUnloadDll == nullptr) return rslt;// if somebody is so tired to forgot obtain address for NTAPI
+	if (ModuleHandle == nullptr) return; //return ERROR_FILE_NOT_FOUND;
+	/*NTSTATUS rslt = NULL; // CodeAnalyzer : Var Init Rule 
+	if (callLdrUnloadDll == nullptr) return rslt; // if somebody is so tired to forgot obtain address for NTAPI
 	std::string ModulePath = Utils::GetLibNameFromHandle(ModuleHandle); // extract untill it mapped
 	static DWORD tmpMDL = (DWORD)ModuleHandle; // save pointer with unchangable address
 	MiniJumper::CustomHooks::RestorePrologue((DWORD)callLdrUnloadDll, (PVOID)fTr2, ldrUnload, 5);
 	rslt = callLdrUnloadDll(ModuleHandle); // let`s module will be unmapped for sure
 	fTr2 = MiniJumper::CustomHooks::MakeJump((DWORD)callLdrUnloadDll, (DWORD)&LdrUnloadDll, ldrUnload, 5);
-	if (NT_ERROR(rslt)) return rslt; // we are not needed in any surprises
+	if (NT_ERROR(rslt)) return rslt; // we are not needed in any surprises*/
+	std::string ModulePath = Utils::GetLibNameFromHandle(ModuleHandle); // extract untill it mapped
 #ifdef ARTEMIS_DEBUG
-	Utils::LogInFile(ARTEMIS_LOG, "[LdrUnloadDll] %s unloaded | TID: %d\n", ModulePath.c_str(), GetCurrentThreadId());
+	Utils::LogInFile(ARTEMIS_LOG, "[LdrUnloadDll] %s unloaded | Base: 0x%X | TID: %d\n",
+	ModulePath.c_str(), (DWORD)ModuleHandle, GetCurrentThreadId());
 #endif
-	fireSignal.acquire(); // red
-	{
-		orderedMapping.erase(orderedMapping.find(tmpMDL));
+	// C++17 RAII-Style Scope (Critical Section)
+	//{ 
+		//std::scoped_lock lock { orderedMapping_mutex, orderedIdentify_mutex };
+		/*orderedMapping.erase(orderedMapping.find(tmpMDL));
 		CHAR szFileName[MAX_PATH + 1]; GetModuleFileNameA((HMODULE)tmpMDL, szFileName, MAX_PATH + 1);
-		DWORD CRC32 = Utils::GenerateCRC32(szFileName); 
-		orderedIdentify.erase(orderedIdentify.find(CRC32));
-	}
-	fireSignal.release(); // blue
-	return rslt;
+		DWORD CRC32 = Utils::GenerateCRC32(szFileName);
+		orderedIdentify.erase(orderedIdentify.find(CRC32));*/
+	//}
+	//return rslt;
+	__asm jmp fTr2
 }
 typedef NTSTATUS(__stdcall* ptrLdrLoadDll)(PWCHAR PathToFile, ULONG FlagsL, 
 PUNICODE_STRING ModuleFileName, HMODULE* ModuleHandle);
@@ -81,7 +86,7 @@ ptrLdrLoadDll callLdrLoadDll = nullptr;
 NTSTATUS __stdcall LdrLoadDll(PWCHAR PathToFile, ULONG FlagsL, PUNICODE_STRING ModuleFileName, HMODULE* ModuleHandle)
 {
 	NTSTATUS rslt = NULL; // CodeAnalyzer : Var Init Rule 
-	if (callLdrLoadDll == nullptr) return rslt;// if somebody is so tired to forgot obtain address for NTAPI
+	if (callLdrLoadDll == nullptr) return rslt; // if somebody is so tired to forgot obtain address for NTAPI
 	MiniJumper::CustomHooks::RestorePrologue((DWORD)callLdrLoadDll, (PVOID)fTr1, ldrLoad, 5);
 	rslt = callLdrLoadDll(PathToFile, FlagsL, ModuleFileName, ModuleHandle); // let`s module will be mapped for sure
 	fTr1 = MiniJumper::CustomHooks::MakeJump((DWORD)callLdrLoadDll, (DWORD)&LdrLoadDll, ldrLoad, 5);
@@ -90,22 +95,23 @@ NTSTATUS __stdcall LdrLoadDll(PWCHAR PathToFile, ULONG FlagsL, PUNICODE_STRING M
 	if (ModuleHandle != nullptr) // fcking pointer safety
 	{
 #ifdef ARTEMIS_DEBUG
-		Utils::LogInFile(ARTEMIS_LOG, "[LdrLoadDll] %ls loaded!\n(Base: 0x%X | TID: %d)\n",
+		Utils::LogInFile(ARTEMIS_LOG, "[LdrLoadDll] %ls loaded! Base: 0x%X | TID: %d\n",
 		ModulePath.c_str(), *ModuleHandle, GetCurrentThreadId());
 #endif
-		fireSignal.acquire(); // red
+		LPMODULEINFO mem = Utils::GetModuleMemoryInfo(*ModuleHandle);
+		if (mem != nullptr)
 		{
-			LPMODULEINFO mem = Utils::GetModuleMemoryInfo(*ModuleHandle);
-			if (mem != nullptr)
-			{
-			    orderedMapping.insert(orderedMapping.begin(), std::pair<DWORD, DWORD>((DWORD)*ModuleHandle, mem->SizeOfImage));
+			// C++17 RAII-Style Scope
+			//{ 
+				//std::scoped_lock lock { orderedMapping_mutex, orderedIdentify_mutex };
+				orderedMapping.insert(orderedMapping.begin(),
+				std::pair<DWORD, DWORD>((DWORD)*ModuleHandle, mem->SizeOfImage));
 				CHAR szFileName[MAX_PATH + 1]; GetModuleFileNameA(*ModuleHandle, szFileName, MAX_PATH + 1);
-				DWORD CRC32 = Utils::GenerateCRC32(szFileName); 
-				std::string DllName = Utils::GetLibNameFromHandle(*ModuleHandle);
+				DWORD CRC32 = Utils::GenerateCRC32(szFileName, nullptr);
+				std::string DllName = Utils::GetLibNameFromHandle(*ModuleHandle, szFileName);
 				orderedIdentify.insert(orderedIdentify.begin(), std::pair<DWORD, std::string>(CRC32, DllName));
-			}
+			//}
 		}
-		fireSignal.release(); // blue
 	}
 	return rslt;
 }
@@ -119,28 +125,20 @@ void __stdcall ModuleScanner(ArtemisConfig* cfg)
 		return;
 	}
 #ifdef ARTEMIS_DEBUG
-	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for ModuleScanner!\n");
+	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for ModuleScanner! Thread id: %d\n", GetCurrentThreadId());
 #endif
 	if (cfg->ModuleScanner) return;
 	cfg->ModuleScanner = true;
-	auto IsNotWinOrAVModule = [](const std::string& m_path) -> bool
+	auto IsNotWinOrAVModule = [](const std::string& m_path) -> bool // Will be modified, found false-positives and etc..
 	{
 		SLibVersionInfo dll_ver; if (GetLibVersionInfo(m_path.c_str(), &dll_ver))
 		{
-#ifdef ARTEMIS_DEBUG
-			//Utils::LogInFile(ARTEMIS_LOG, "[VERSION_INFO] Company: %s len: %d | Product: %s len: %d\n",
-			//dll_ver.strCompanyName.c_str(), dll_ver.strCompanyName.length(), 
-			//dll_ver.strProductName.c_str(), dll_ver.strProductName.length());
-#endif
 			if (Utils::findStringIC(m_path, R"(Windows\System32)") ||
 			Utils::findStringIC(m_path, R"(Program Files\ESET\ESET Security\x86)"))
 			{
 				if (dll_ver.strCompanyName.length() >= 4 && dll_ver.strProductName.length() >= 4) return false;
 			}
 		}
-#ifdef ARTEMIS_DEBUG
-		//else Utils::LogInFile(ARTEMIS_LOG, "[VERSION_INFO] %d Error! %s\n", GetLastError(), m_path.c_str());
-#endif
 		return true;
 	};
 	decltype(auto) DiagnosticMSG = [](const std::string& reason_text) -> DWORD
@@ -154,50 +152,54 @@ void __stdcall ModuleScanner(ArtemisConfig* cfg)
 	{
 		callLdrLoadDll = (ptrLdrLoadDll)Utils::RuntimeIatResolver("ntdll.dll", "LdrLoadDll");
 		if (callLdrLoadDll == nullptr) return DiagnosticMSG("[FAILURE $1] nullptr | LdrLoadDll\n");
-		fTr1 = MiniJumper::CustomHooks::MakeJump((DWORD)callLdrLoadDll, (DWORD)&LdrLoadDll, ldrLoad, 5);
+		/*fTr1 = MiniJumper::CustomHooks::MakeJump((DWORD)callLdrLoadDll, (DWORD)&LdrLoadDll, ldrLoad, 5);
 		if (fTr1 != NULL) DiagnosticMSG("[INSTALLER-2] LdrLoadDll hook was successfully installed!\n");
-		else return DiagnosticMSG("[Hooking Error #1] By some reasons, hook is not exist in to the list.\n");
+		else return DiagnosticMSG("[Hooking Error #1] By some reasons, hook is not exist in to the list.\n");*/
 		///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 		callLdrUnloadDll = (ptrLdrUnloadDll)Utils::RuntimeIatResolver("ntdll.dll", "LdrUnloadDll");
 		if (callLdrUnloadDll == nullptr) return DiagnosticMSG("[FAILURE $2] nullptr | LdrUnloadDll\n");
-		fTr2 = MiniJumper::CustomHooks::MakeJump((DWORD)callLdrUnloadDll, (DWORD)&LdrUnloadDll, ldrUnload, 5);
+		/*fTr2 = MiniJumper::CustomHooks::MakeJump((DWORD)callLdrUnloadDll, (DWORD)&LdrUnloadDll, ldrUnload, 5);
 		if (fTr2 != NULL) DiagnosticMSG("[INSTALLER-2] LdrUnloadDll hook was successfully installed!\n");
-		else return DiagnosticMSG("[Hooking Error #2] By some reasons, hook is not exist in to the list!\n");
+		else return DiagnosticMSG("[Hooking Error #2] By some reasons, hook is not exist in to the list!\n");*/
 		return 0xDEADBEEF;
 	}; 
-	PushNativeHooks(); Utils::BuildModuledMemoryMap();
-	while (true)
+	// let`s parse it only one times, cuz we need to know wich exactly modules was loaded before us
+	//Utils::BuildModuledMemoryMap(); // thread-safe -> called only once before hooks will be installed
+	//PushNativeHooks(); // now - we can obtain a fresh lists at the run-time, big advantage for speed perfomance
+	//return; // Remove after testing!!!
+	while (true) // Runtime Duplicates-Module Scanner && ProxyDLL Detector
 	{
-		// Runtime Duplicates-Module Scanner && ProxyDLL Detector
-		for (const auto& it : orderedMapping)
-		{
-			if (it.first == NULL) continue; // fix for dll unloading from another threads
-			if ((it.first != (DWORD)GetModuleHandleA(NULL) && it.first != (DWORD)cfg->hSelfModule) && 
-			!Utils::IsVecContain(cfg->ExcludedModules, (PVOID)it.first)) 
+		//{ // C++17 RAII-Style Scope
+			//std::scoped_lock lock { orderedMapping_mutex, orderedIdentify_mutex };
+			Utils::BuildModuledMemoryMap(); // on considering, for test period must be as old-worked style
+			for (const auto& it : orderedMapping)
 			{
-				CHAR szFileName[MAX_PATH + 1]; GetModuleFileNameA((HMODULE)it.first, szFileName, MAX_PATH + 1);
-				if (Utils::IsModuleDuplicated((HMODULE)it.first, orderedIdentify))
+				if (it.first == NULL) continue; // for sure
+				if ((it.first != (DWORD)GetModuleHandleA(NULL) && it.first != (DWORD)cfg->hSelfModule) &&
+				!Utils::IsVecContain(cfg->ExcludedModules, (PVOID)it.first))
 				{
-					if (IsNotWinOrAVModule(szFileName))
+					// C:\Windows\System32\TextShaping.dll - Empty version info, fix false-positive by cert check! (Microsoft)
+					std::string NameOfDLL = "", szFileName = ""; DWORD fSize = 0x0; // Optimizated (Less-recursive calls!)
+					if (Utils::IsModuleDuplicated((HMODULE)it.first, szFileName, &fSize, orderedIdentify, NameOfDLL))
 					{
-						std::string NameOfDLL = Utils::GetDllName(szFileName);
-						MEMORY_BASIC_INFORMATION mme{ 0 }; ARTEMIS_DATA data;
-						VirtualQuery((PVOID)it.first, &mme, sizeof(MEMORY_BASIC_INFORMATION));
-						data.baseAddr = (PVOID)it.first; data.EmptyVersionInfo = true;
-						data.MemoryRights = mme.AllocationProtect; DWORD fSize = 0x0; 
-						FILE* nFile = fopen(szFileName, "rb");
-						if (nFile != nullptr)
-						{
-							fSize = Utils::getFileSize(nFile);
-							fclose(nFile);
+						/*#ifdef ARTEMIS_DEBUG
+						Utils::LogInFile(ARTEMIS_LOG, "[MODULE FILLER] %s\nBase: 0x%X | Size: 0x%X\n",
+						szFileName.c_str(), it.first, it.second);
+						#endif*/
+						if (IsNotWinOrAVModule(szFileName)) // FIX LdrUnloadDll RECURSION FROM THAT SHIT!
+						{ 
+							MEMORY_BASIC_INFORMATION mme { 0 }; ARTEMIS_DATA data;
+							VirtualQuery((PVOID)it.first, &mme, sizeof(MEMORY_BASIC_INFORMATION));
+							data.baseAddr = (PVOID)it.first; data.EmptyVersionInfo = true;
+							data.MemoryRights = mme.AllocationProtect;
+							data.regionSize = fSize; data.dllName = NameOfDLL;
+							data.dllPath = szFileName; data.type = DetectionType::ART_PROXY_LIBRARY;
+							cfg->callback(&data); cfg->ExcludedModules.push_back((PVOID)it.first);
 						}
-						data.regionSize = fSize; data.dllName = NameOfDLL; 
-						data.dllPath = szFileName; data.type = DetectionType::ART_PROXY_LIBRARY;
-						cfg->callback(&data); cfg->ExcludedModules.push_back((PVOID)it.first);
 					}
 				}
 			}
-		}
+		//}
 		Sleep(cfg->MemoryScanDelay);
 	}
 }

--- a/ArtemisComponents/Arthemida-2/ArtModules/ThreadScanner.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/ThreadScanner.h
@@ -10,7 +10,7 @@ void __stdcall ScanForDllThreads(ArtemisConfig* cfg)
 	if (cfg->ThreadScanner) return;
 	cfg->ThreadScanner = true;
 #ifdef ARTEMIS_DEBUG
-	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for ScanForDllThreads!\n");
+	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for ScanForDllThreads! Thread id: %d\n", GetCurrentThreadId());
 #endif
 	while (true) 
 	{

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj
@@ -77,7 +77,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -105,7 +105,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <LanguageStandard_C>Default</LanguageStandard_C>
       <Optimization>Disabled</Optimization>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ConsoleHost.cpp
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ConsoleHost.cpp
@@ -31,7 +31,7 @@ void __stdcall ArthemidaCallback(ARTEMIS_DATA* artemis)
 		break;
 	case DetectionType::ART_PROXY_LIBRARY:
 		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected Proxy DLL! Base: 0x%X | DllName: %s\n\
-		Path: %s\nSize: %d | Empty Version Info: %d\n",
+		\r\r\rPath: %s\nSize: %d | Empty Version Info: %d\n",
 		artemis->baseAddr, artemis->dllName.c_str(), artemis->dllPath.c_str(), 
 		artemis->regionSize, (int)artemis->EmptyVersionInfo);
 		break;
@@ -85,10 +85,11 @@ int main()
 {
 	SetConsoleCP(1251); SetConsoleOutputCP(1251);
 	system("color 02"); SetConsoleTitleA("Arthemida-2 AntiCheat Lightweight Testing");
+	printf("ConsoleHost main thread started! Thread ID: %d\n", GetCurrentThreadId());
 	ArtemisConfig cfg; LoadLibraryA("version.dll");
 	//cfg.DetectThreads = true; 
 	//cfg.ThreadScanDelay = 1000;
-	
+	// For now - Module Scanner on improvments stage, found a better ways to figure out all problems per one-shot :)
 	cfg.DetectModules = true; 
 	cfg.ModuleScanDelay = 1000;
 	
@@ -115,7 +116,7 @@ int main()
 	for (;;) 
 	{
 		Sleep(3000); static bool first = false; if (!first) { first = true; printf("\n"); }
-		printf("\n[HEART-BEAT] Console is working normally! Press any key to stop.\n\n");
+		printf("\n[HEART-BEAT] Console is working normally! Thread ID: %d | Press any key to stop.\n\n", GetCurrentThreadId());
 	} });
 
 	IArtemisInterface* art = IArtemisInterface::InstallArtemisMonitor(&cfg);
@@ -125,6 +126,7 @@ int main()
 		// test detection of illegal calls (return addresses checking)
 		//RetTest::TestStaticMethod();
 		//testObj.TestMemberMethod(); 
+		//LoadLibraryA("test.dll");
 	}
 	else Utils::LogInFile(ARTEMIS_LOG, "[ARTEMIS-2] Failure on start :( Last error code: %d\n", GetLastError());
 	while (true) 
@@ -133,7 +135,8 @@ int main()
 		if (_getch()) 
 		{ 
 			#pragma warning(suppress: 6258)
-			TerminateThread((HANDLE)heart.native_handle(), 0x0); printf("[HEART-BEAT] Stopped.\n"); 
+			TerminateThread((HANDLE)heart.native_handle(), 0x0); 
+			printf("[HEART-BEAT] Stopped. Thread id: %d | Heart-beat thread id: %d\n", GetCurrentThreadId(), heart.get_id()); 
 			break; 
 		}
 	}


### PR DESCRIPTION
…из-за которого не заполнялись корректно списки модулей в модульном сканнере.                            2. Оптимизация утиля и модульного сканера - уменьшено кол-во рекурсивных/повторяющихся/кросс-вызовов.                             3. Исправлен баг с парсингом списка имен в функции IsInModuledAddressSpace в которой проверялся всегда только первый аргумент.