### PR TITLE
> Значительно усовершенствован алгоритм обнаружения прокси-дллок, вме…

### DIFF
--- a/ArtemisComponents/Arthemida-2/API/ArtemisComponents.cpp
+++ b/ArtemisComponents/Arthemida-2/API/ArtemisComponents.cpp
@@ -12,6 +12,14 @@ ArtemisIncapsulator::ArtemisIncapsulator(ArtemisConfig* cfg)
 #ifdef ARTEMIS_DEBUG
 		Utils::LogInFile(ARTEMIS_LOG, "[SINGLETON] Called the second generation constructor!\n");
 #endif
+		CheckIfFileProtected = (PtrIfFileProtected)Utils::RuntimeIatResolver("Sfc.dll", "SfcIsFileProtected");
+		if (CheckIfFileProtected == nullptr)
+		{
+#ifdef ARTEMIS_DEBUG
+			Utils::LogInFile(ARTEMIS_LOG, "[ERROR] Can`t obtain export from Sfc.dll for SfcIsFileProtected.\n");
+#endif
+			return;
+		}
 		lpGetMappedFileNameA = (LPFN_GetMappedFileNameA)Utils::RuntimeIatResolver("psapi.dll", "GetMappedFileNameA");
 		if (lpGetMappedFileNameA == nullptr)
 		{

--- a/ArtemisComponents/Arthemida-2/API/ArtemisTypes.h
+++ b/ArtemisComponents/Arthemida-2/API/ArtemisTypes.h
@@ -29,7 +29,6 @@ namespace ArtemisData
 		std::string dllName = "";
 		std::string dllPath = "";
 		std::string HackName = "";
-		bool EmptyVersionInfo = false;
 	};
 	typedef void(__stdcall* ArtemisCallback)(ARTEMIS_DATA* artemis);
 	struct ArtemisConfig

--- a/ArtemisComponents/Arthemida-2/ArtModules/HeuristicScanner.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/HeuristicScanner.h
@@ -38,7 +38,7 @@ void __stdcall SigScanner(ArtemisConfig* cfg) // CAUTION! Still remaining on dev
 				{
 					CHAR szFilePath[MAX_PATH + 1]; GetModuleFileNameA((HMODULE)it.first, szFilePath, MAX_PATH + 1);
 					std::string NameOfDLL = Utils::GetDllName(szFilePath);
-					MEMORY_BASIC_INFORMATION mme{ 0 }; ARTEMIS_DATA data; data.EmptyVersionInfo = true;
+					MEMORY_BASIC_INFORMATION mme{ 0 }; ARTEMIS_DATA data; 
 					VirtualQuery((PVOID)it.first, &mme, sizeof(MEMORY_BASIC_INFORMATION));
 					data.baseAddr = (PVOID)it.first; data.MemoryRights = mme.AllocationProtect;
 					data.regionSize = mme.RegionSize; data.dllName = NameOfDLL; data.dllPath = szFilePath;

--- a/ArtemisComponents/Arthemida-2/ArtModules/MemoryGuard.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/MemoryGuard.h
@@ -17,7 +17,7 @@ void __thiscall IArtemisInterface::ConfirmLegitReturn(const char* function_name,
 		lpGetMappedFileNameA(GetCurrentProcess(), (PVOID)return_address, MappedName, sizeof(MappedName));
 		///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 		MEMORY_BASIC_INFORMATION mme{ 0 }; ARTEMIS_DATA data; 
-		data.EmptyVersionInfo = true; std::string DllName = Utils::GetDllName(MappedName);
+		 std::string DllName = Utils::GetDllName(MappedName);
 		VirtualQuery(return_address, &mme, sizeof(MEMORY_BASIC_INFORMATION));
 		data.baseAddr = (LPVOID)return_address; 
 		data.MemoryRights = mme.AllocationProtect; 
@@ -67,7 +67,7 @@ void __stdcall MemoryGuardScanner(ArtemisConfig* cfg) // On tehnical work
 			{
 				if (!Utils::IsVecContain(cfg->ExcludedPatches, it.second))
 				{
-					ARTEMIS_DATA data; data.baseAddr = it.second; data.EmptyVersionInfo = true;
+					ARTEMIS_DATA data; data.baseAddr = it.second; 
 					data.MemoryRights = PAGE_EXECUTE_READWRITE; data.regionSize = 0x5;
 					data.dllName = "client.dll"; data.dllPath = "MTA\\mods\\deadmatch\\client.dll";
 					data.type = DetectionType::ART_MEMORY_CHANGED;

--- a/ArtemisComponents/Arthemida-2/ArtModules/MemoryScanner.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/MemoryScanner.h
@@ -56,7 +56,7 @@ void __stdcall MemoryScanner(ArtemisConfig* cfg)
 									ARTEMIS_DATA data; data.baseAddr = (PVOID)foundIAT;
 									data.MemoryRights = i->Protect; data.regionSize = i->RegionSize;
 									data.dllName = "unknown"; data.dllPath = "unknown";
-									data.type = DetectionType::ART_MANUAL_MAP; data.EmptyVersionInfo = true;
+									data.type = DetectionType::ART_MANUAL_MAP; 
 									cfg->callback(&data); cfg->ExcludedImages.push_back(i->BaseAddress);
 								}
 							}

--- a/ArtemisComponents/Arthemida-2/ArtModules/ThreadScanner.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/ThreadScanner.h
@@ -32,7 +32,7 @@ void __stdcall ScanForDllThreads(ArtemisConfig* cfg)
 						if (!Utils::IsMemoryInModuledRange(tempBase) && 
 						!Utils::IsVecContain(cfg->ExcludedThreads, (LPVOID)tempBase))
 						{
-							MEMORY_BASIC_INFORMATION mme{ 0 }; ARTEMIS_DATA data; data.EmptyVersionInfo = true;
+							MEMORY_BASIC_INFORMATION mme{ 0 }; ARTEMIS_DATA data;
 							VirtualQuery((LPCVOID)tempBase, &mme, sizeof(MEMORY_BASIC_INFORMATION)); 
 							data.baseAddr = (LPVOID)tempBase; 
 							data.MemoryRights = mme.AllocationProtect; 

--- a/ArtemisComponents/Arthemida-2/LauncherInclude/ArtSafeLaunch.h
+++ b/ArtemisComponents/Arthemida-2/LauncherInclude/ArtSafeLaunch.h
@@ -27,7 +27,7 @@ namespace SafeLaunch
 		{
 			auto getOSver = []()
 			{
-				NTSTATUS(WINAPI * RtlGetVersion)(LPOSVERSIONINFOEXW); OSVERSIONINFOEXW osInfo;
+				NTSTATUS(__stdcall *RtlGetVersion)(LPOSVERSIONINFOEXW) = nullptr; OSVERSIONINFOEXW osInfo { 0 };
 				*(FARPROC*)&RtlGetVersion = GetProcAddress(GetModuleHandleA("ntdll"), "RtlGetVersion");
 				if (NULL != RtlGetVersion)
 				{
@@ -116,7 +116,7 @@ namespace SafeLaunch
 			lpProcessAttributes, lpThreadAttributes, bInheritHandles,
 			ulFlags, lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
 			if (lpProcessInformation->hProcess == NULL || rslt == NULL) return NULL;
-			DISPLAY_DEVICE DevInfo; DevInfo.cb = sizeof(DISPLAY_DEVICE);
+			DISPLAY_DEVICE DevInfo { 0 }; DevInfo.cb = sizeof(DISPLAY_DEVICE);
 			EnumDisplayDevicesA(NULL, 0, &DevInfo, 0);
 			std::string VideoCard = DevInfo.DeviceString;
 			HANDLE hMutex = CreateMutexA(FALSE, FALSE, VideoCard.c_str());
@@ -132,16 +132,18 @@ namespace SafeLaunch
 #ifdef SAFE_LAUNCH_DEBUG
 				printf("[UNHOOKING] Hook was found, trying to remove it...\n");
 #endif
-				if (CustomHooks::RestorePrologue(ZwAddr, prologue, 5)) 
+				if (CustomHooks::RestorePrologue(ZwAddr, (PVOID)fTrampoline, prologue, 5))
 				{
 #ifdef SAFE_LAUNCH_DEBUG
 					printf("[REMOVED] Inline hook was erased, original bytes restored!\n");
 #endif
 				}
 #ifdef SAFE_LAUNCH_DEBUG
-				else printf("[Unhooking Error] Failed to restore original code.\n[REPORT] System Error Code: %d\n", GetLastError());
+				else printf("[Unhooking Error] Failed to restore original code.\n"
+				"\r\r\r[REPORT] System Error Code: %d\n", GetLastError());
 			}
-			else printf("[Unhooking Error] By some reasons, hook is not exist in to the list!\n[REPORT] System Error Code: %d\n", GetLastError());
+			else printf("[Unhooking Error] By some reasons, hook is not exist in to the list!\n"
+			"\r\r\r[REPORT] System Error Code : % d\n", GetLastError());
 #endif
 			if (syscall != nullptr)
 			{

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj
@@ -170,8 +170,6 @@
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\CRC32.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\MiniJumper.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\sigscan.h" />
-    <ClInclude Include="..\..\Arthemida-2\ArtUtils\SString.h" />
-    <ClInclude Include="..\..\Arthemida-2\ArtUtils\SString.hpp" />
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\Utils.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj.filters
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj.filters
@@ -74,12 +74,6 @@
     <ClInclude Include="..\..\Arthemida-2\ArtModules\CServiceMon.h">
       <Filter>Arthemida-2\ArtModules</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Arthemida-2\ArtUtils\SString.h">
-      <Filter>Arthemida-2\ArtUtils</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\Arthemida-2\ArtUtils\SString.hpp">
-      <Filter>Arthemida-2\ArtUtils</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\MiniJumper.h">
       <Filter>Arthemida-2\ArtUtils</Filter>
     </ClInclude>

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ConsoleHost.cpp
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ConsoleHost.cpp
@@ -30,13 +30,12 @@ void __stdcall ArthemidaCallback(ARTEMIS_DATA* artemis)
 		artemis->baseAddr, artemis->regionSize);
 		break;
 	case DetectionType::ART_PROXY_LIBRARY:
-		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected Proxy DLL! Base: 0x%X | DllName: %s\n\
-		\r\r\rPath: %s\nSize: %d | Empty Version Info: %d\n",
-		artemis->baseAddr, artemis->dllName.c_str(), artemis->dllPath.c_str(), 
-		artemis->regionSize, (int)artemis->EmptyVersionInfo);
+		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected Proxy DLL! Base: 0x%X | Size: %d KB | DllName: %s\n\
+		\r\r\rPath: %s\n\n", artemis->baseAddr, (artemis->regionSize / 1024), 
+		artemis->dllName.c_str(), artemis->dllPath.c_str());
 		break;
 	case DetectionType::ART_FAKE_LAUNCHER:
-		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected fake launcher!\n");
+		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected Startup from Fake Launcher!\n");
 		break;
 	case DetectionType::ART_RETURN_ADDRESS:
 		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected Return to Hack Function! Address: 0x%X\n", artemis->baseAddr);
@@ -46,20 +45,20 @@ void __stdcall ArthemidaCallback(ARTEMIS_DATA* artemis)
 		artemis->baseAddr, artemis->regionSize, artemis->MemoryRights);
 		break;
 	case DetectionType::ART_MEMORY_CHANGED:
-		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected Illegal module!\nBase: 0x%X | Rights: 0x%X | Size: %d\n",
-		artemis->baseAddr, artemis->MemoryRights, artemis->regionSize);
+		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected Illegal module!\nBase: 0x%X | Rights: 0x%X | Size: %d KB\n",
+		artemis->baseAddr, artemis->MemoryRights, (artemis->regionSize / 1024));
 		break;
 	case DetectionType::ART_SIGNATURE_DETECT:
-		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected Illegal module!\nBase: 0x%X | Rights: 0x%X | Size: %d\n",
-		artemis->baseAddr, artemis->MemoryRights, artemis->regionSize);
+		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected Illegal module!\nBase: 0x%X | Rights: 0x%X | Size: %d KB\n",
+		artemis->baseAddr, artemis->MemoryRights, (artemis->regionSize / 1024));
 		break;
 	case DetectionType::ART_ILLEGAL_SERVICE:
 		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected Illegal service!\n");
-		//"Path: %s | \nName: %s  | Description: %s | \nType: %d | BootSet: %s | Group: %s\n | Signed by: %s | Has Version Info: %d\n");
+		//"Path: %s | \nName: %s  | Description: %s | \nType: %d | BootSet: %s | Group: %s\n | Signed by: %s\n");
 		break;
 	default:
-		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Unknown detection code! Base: 0x%X | DllName: %s\nPath: %s\nSize: %d | Empty Version Info: %d\n",
-		artemis->baseAddr, artemis->dllName.c_str(), artemis->dllPath.c_str(), artemis->regionSize, (int)artemis->EmptyVersionInfo);
+		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Unknown detection code! Base: 0x%X | Size: %d bytes | DllName: %s\n"
+		"\r\r\rPath: %s\n", artemis->baseAddr, artemis->regionSize, artemis->dllName.c_str(), artemis->dllPath.c_str());
 		break;
 	}
 	Utils::LogInFile(ARTEMIS_LOG, "\n\n");
@@ -89,7 +88,7 @@ int main()
 	ArtemisConfig cfg; LoadLibraryA("version.dll");
 	//cfg.DetectThreads = true; 
 	//cfg.ThreadScanDelay = 1000;
-	// For now - Module Scanner on improvments stage, found a better ways to figure out all problems per one-shot :)
+
 	cfg.DetectModules = true; 
 	cfg.ModuleScanDelay = 1000;
 	
@@ -108,7 +107,7 @@ int main()
 	//cfg.IllegalPatterns.insert(std::pair<std::string, std::tuple<const char*, const char*>>
 	//(hack_name, std::make_tuple(pattern, mask))); // must be incapsulated
 
-	//cfg.DetectFakeLaunch = true;
+	cfg.DetectFakeLaunch = true;
 	cfg.callback = (ArtemisCallback)ArthemidaCallback; 
 
 	Utils::LogInFile(ARTEMIS_LOG, "[ARTEMIS-2] Configured and ready, press any key to load...\n"); 
@@ -126,7 +125,7 @@ int main()
 		// test detection of illegal calls (return addresses checking)
 		//RetTest::TestStaticMethod();
 		//testObj.TestMemberMethod(); 
-		//LoadLibraryA("test.dll");
+		LoadLibraryA("test.dll"); // For heuristic-scans on future & excluding false-positives in ProxyDLL detection.
 	}
 	else Utils::LogInFile(ARTEMIS_LOG, "[ARTEMIS-2] Failure on start :( Last error code: %d\n", GetLastError());
 	while (true) 
@@ -135,7 +134,8 @@ int main()
 		if (_getch()) 
 		{ 
 			#pragma warning(suppress: 6258)
-			TerminateThread((HANDLE)heart.native_handle(), 0x0); 
+			TerminateThread((HANDLE)heart.native_handle(), 0x0);
+			#pragma warning(suppress: 6273)
 			printf("[HEART-BEAT] Stopped. Thread id: %d | Heart-beat thread id: %d\n", GetCurrentThreadId(), heart.get_id()); 
 			break; 
 		}


### PR DESCRIPTION
…сто громоздкого кода чтения ресурса версион инфо, который легко можно было подделать + проверяльщик постоянно вызывал рекурсивную выгрузку в kernelbase.dll -> FreeLibrary что приводило к очень затратной нагрузке. Дополнительная оптимизация утиля и его кросс-вызовов, пофикшен логический баг в сверке дубликата в списке модулей а так же раздувание списка дублирующими записями, исправлен утиль для траверса экспортов который владел той же проблемой с забиванием списка мусором, EAT парсер пригодится в дальнейших этапах а излишний громоздкой утиль был вырезан (То же получене версион инфо с рекурсией в комплекте).