### PR TITLE
Fix of DLL Cloacking ByPass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@
 *.log
 *.testlog
 *.manifest
+/TestDLL/TestDLL
+/SecurityTrainings
+/t1ha-2.0.4.zip

--- a/ArtemisComponents/Arthemida-2/API/ArtemisTypes.h
+++ b/ArtemisComponents/Arthemida-2/API/ArtemisTypes.h
@@ -13,12 +13,13 @@ namespace ArtemisData
 		ART_UNKNOWN_DETECT = 0,
 		ART_ILLEGAL_THREAD = 1,
 		ART_PROXY_LIBRARY = 2,
-		ART_FAKE_LAUNCHER = 3,
-		ART_RETURN_ADDRESS = 4,
-		ART_MANUAL_MAP = 5,
-		ART_MEMORY_CHANGED = 6,
-		ART_SIGNATURE_DETECT = 7,
-		ART_ILLEGAL_SERVICE = 8
+		ART_DLL_CLOACKING = 3,
+		ART_FAKE_LAUNCHER = 4,
+		ART_RETURN_ADDRESS = 5,
+		ART_MANUAL_MAP = 6,
+		ART_MEMORY_CHANGED = 7,
+		ART_SIGNATURE_DETECT = 8,
+		ART_ILLEGAL_SERVICE = 9
 	};
 	struct ARTEMIS_DATA
 	{
@@ -36,6 +37,8 @@ namespace ArtemisData
 		// basic stuff
 		bool SingletonCalled = false;
 		HANDLE hSelfModule = nullptr;
+		HANDLE CurrProc = nullptr;
+		std::vector<HANDLE> OwnThreads;
 		ArtemisCallback callback = nullptr;
 		// anticheat controller options
 		bool DetectThreads = false;

--- a/ArtemisComponents/Arthemida-2/ArtModules/ModuleScanner.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/ModuleScanner.h
@@ -28,23 +28,16 @@ void __stdcall ModuleScanner(ArtemisConfig* cfg)
 	DWORD appHost = (DWORD)GetModuleHandleA(NULL); // Optimizated (Now is non-recursive call!)
 	while (true) // Runtime Duplicates-Module Scanner && ProxyDLL Detector
 	{
-		Utils::BuildModuledMemoryMap(); // Refactored parser -> now faster on 70% than previous!
+		Utils::BuildModuledMemoryMap(cfg->CurrProc); // Refactored parser -> now faster on 70% than previous!
 		for (const auto& it : orderedMapping)
 		{
 			if (it.first == 0x0 || it.second == 0x0) continue; // validating every page record from memory list
 			if ((it.first != appHost && it.first != (DWORD)cfg->hSelfModule) &&
 			!Utils::IsVecContain(cfg->ExcludedModules, (PVOID)it.first))
 			{
-				/*#ifdef ARTEMIS_DEBUG
-				Utils::LogInFile(ARTEMIS_LOG, "[MODULE FILLER] Base: 0x%X | Size: 0x%X\n", it.first, it.second);
-				#endif*/
 				std::string NameOfDLL = "", szFileName = ""; // Optimizated (Less-recursive calls!)
 				if (Utils::IsModuleDuplicated((HMODULE)it.first, szFileName, orderedIdentify, NameOfDLL))
 				{
-					/*#ifdef ARTEMIS_DEBUG
-					Utils::LogInFile(ARTEMIS_LOG, "[MODULE FILLER] %s\nBase: 0x%X | Size: 0x%X\n",
-					szFileName.c_str(), it.first, it.second);
-					#endif*/
 					if (!Utils::OsProtectedFile(Utils::CvAnsiToWide(szFileName).c_str())) // New advanced algorithm!
 					{
 						MEMORY_BASIC_INFORMATION mme { 0 }; ARTEMIS_DATA data;

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj
@@ -122,6 +122,7 @@
       <SetChecksum>true</SetChecksum>
       <FixedBaseAddress>false</FixedBaseAddress>
       <LinkErrorReporting>NoErrorReport</LinkErrorReporting>
+      <Profile>true</Profile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -150,6 +151,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <Profile>true</Profile>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/ArtemisComponents/ConsoleTests/InvasionTerminal/AssaultConsole.cpp
+++ b/ArtemisComponents/ConsoleTests/InvasionTerminal/AssaultConsole.cpp
@@ -18,6 +18,7 @@ int main()
 {
 	system("color 06"); SetConsoleTitleA("[Artemis-2] Invasion Terminal");
 	printf("Invasion Terminal started!\n\n");
+	
 	SafeLaunch::ProcessGate procGate(CreateProcessW);
 	STARTUPINFOW info = { sizeof(info) }; PROCESS_INFORMATION processInfo;
 	if (procGate.SafeProcess<const wchar_t*, LPSTARTUPINFOW>


### PR DESCRIPTION
Фикс ложных в сканере потоков из-за незаполненого списка модулей и проблемами междупоточной синхры - данные теперь актуализируются по мере необходимости.
Переписан алгоритм поиска IAT среди страниц виртуальной памяти процесса в ммап сканере, больше не сыпит ложных на вов64 процессы и шаред память, улучшена эвристика обнаружения смапленных образов.
Добавлен новый детект для DLL Клоукинга, который сочетает в себе техники маскировок модуля в процессе через очистку PEB/TEB, манипуляции с контекстом потоков для перехвата и тд, потоковый сканер нынче способен палить запрятанную дллку с обрезанными заголовками и инфой с пеба даже среди shared-страниц памяти.
Более детализирован вывод в коллбэк срабатываний, отражается полная картина касающихся вещей того или иного детекта. Оптимизация и рефакторинг кода в утиле и кросс-модульных вызовах.
Античит теперь запускается только с под админ прав, после чего врубает себе привилегию отладчика - дает возможность сканировать потоки и страницы памяти других привилегированных процессов и внутренние вов64 операции, так же это обеспечивает защиту на дурака, одних админ прав будет мало чтобы подрубится к процессу не врубив привилегию отладчика :)
Сканер потоков больше не морозит ничего, сделан пропуск своих собственных потоков сканеров артемиды.