### PR TITLE
Добавлен коллбэк перехвата потоков (Пока требует дополнительных прове…

### DIFF
--- a/ArtemisComponents/Arthemida-2/API/ArtemisComponents.cpp
+++ b/ArtemisComponents/Arthemida-2/API/ArtemisComponents.cpp
@@ -1,7 +1,7 @@
 ﻿/*
     Artemis-2 for MTA Province
 	Target Platform: x32-x86
-	Project by NtKernelMC & holmes0
+	Project by NtKernelMC
 */
 #include ".../../../../Arthemida-2/API/ArtemisComponents.h"
 using namespace ArtComponent;
@@ -58,6 +58,14 @@ ArtemisIncapsulator::ArtemisIncapsulator(ArtemisConfig* cfg)
 		{
 #ifdef ARTEMIS_DEBUG
 			Utils::LogInFile(ARTEMIS_LOG, "[ERROR] Can`t obtain export from ntdll.dll for NtQueryInformationThread.\n");
+#endif
+			return;
+		}
+	    callLdrInitializeThunk = (PtrLdrInitializeThunk)Utils::RuntimeIatResolver("ntdll.dll", "LdrInitializeThunk");
+		if (callLdrInitializeThunk == nullptr)
+		{
+#ifdef ARTEMIS_DEBUG
+			Utils::LogInFile(ARTEMIS_LOG, "[ERROR] Can`t obtain export from ntdll.dll for LdrInitializeThunk.\n");
 #endif
 			return;
 		}
@@ -137,7 +145,7 @@ IArtemisInterface* __stdcall IArtemisInterface::InstallArtemisMonitor(ArtemisCon
 	{
 		if (!cfg->ThreadScanDelay) cfg->ThreadScanDelay = 1000;
 		if (!cfg->ExcludedThreads.empty()) cfg->ExcludedThreads.clear(); 
-		std::thread ThreadsScanner(ScanForDllThreads, cfg); 
+		std::thread ThreadsScanner(ScanForDllThreads, cfg);
 		ThreadsScanner.detach(); cfg->OwnThreads.push_back(ThreadsScanner.native_handle());
 	}
 	if (cfg->DetectModules) // Детект сторонних модулей

--- a/ArtemisComponents/Arthemida-2/API/ArtemisComponents.h
+++ b/ArtemisComponents/Arthemida-2/API/ArtemisComponents.h
@@ -1,7 +1,7 @@
 /*
 	Artemis-2 for MTA Province
 	Target Platform: x32-x86
-	Project by NtKernelMC & holmes0
+	Project by NtKernelMC
 */
 #pragma once
 #include "../../Arthemida-2/API/ArtemisInterface.h"

--- a/ArtemisComponents/Arthemida-2/API/ArtemisInterface.h
+++ b/ArtemisComponents/Arthemida-2/API/ArtemisInterface.h
@@ -1,7 +1,7 @@
 /*
 	Artemis-2 for MTA Province
 	Target Platform: x32-x86
-	Project by NtKernelMC & holmes0
+	Project by NtKernelMC
 */
 #pragma once
 #include "../../Arthemida-2/API/ArtemisTypes.h"

--- a/ArtemisComponents/Arthemida-2/API/ArtemisTypes.h
+++ b/ArtemisComponents/Arthemida-2/API/ArtemisTypes.h
@@ -1,7 +1,7 @@
 /*
 	Artemis-2 for MTA Province
 	Target Platform: x32-x86
-	Project by NtKernelMC & holmes0
+	Project by NtKernelMC
 */
 #pragma once
 #pragma warning (disable : 4477)
@@ -10,16 +10,16 @@ namespace ArtemisData
 {
 	enum class DetectionType
 	{
-		ART_UNKNOWN_DETECT = 0,
-		ART_ILLEGAL_THREAD = 1,
-		ART_PROXY_LIBRARY = 2,
-		ART_DLL_CLOACKING = 3,
-		ART_FAKE_LAUNCHER = 4,
-		ART_RETURN_ADDRESS = 5,
-		ART_MANUAL_MAP = 6,
-		ART_MEMORY_CHANGED = 7,
-		ART_SIGNATURE_DETECT = 8,
-		ART_ILLEGAL_SERVICE = 9
+		ART_UNKNOWN_DETECT,
+		ART_ILLEGAL_THREAD,
+		ART_PROXY_LIBRARY,
+		ART_DLL_CLOACKING,
+		ART_FAKE_LAUNCHER,
+		ART_RETURN_ADDRESS,
+		ART_MANUAL_MAP,
+		ART_MEMORY_CHANGED,
+		ART_SIGNATURE_DETECT,
+		ART_ILLEGAL_SERVICE
 	};
 	struct ARTEMIS_DATA
 	{

--- a/ArtemisComponents/Arthemida-2/ArtModules/AntiFakeLaunch.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/AntiFakeLaunch.h
@@ -1,7 +1,7 @@
 /*
 	Artemis-2 for MTA Province
 	Target Platform: x32-x86
-	Project by NtKernelMC & holmes0
+	Project by NtKernelMC
 */
 void __stdcall ConfirmLegitLaunch(ArtemisConfig* cfg)
 {

--- a/ArtemisComponents/Arthemida-2/ArtModules/CServiceMon.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/CServiceMon.h
@@ -1,7 +1,7 @@
 /*
     Artemis-2 for MTA Province
     Target Platform: x32-x86
-    Project by NtKernelMC & holmes0
+    Project by NtKernelMC
 */
 #pragma once
 #ifndef CSERVICEMON_H

--- a/ArtemisComponents/Arthemida-2/ArtModules/HeuristicScanner.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/HeuristicScanner.h
@@ -1,7 +1,7 @@
 /*
 	Artemis-2 for MTA Province
 	Target Platform: x32-x86
-	Project by NtKernelMC & holmes0
+	Project by NtKernelMC
 */
 #include "ArtemisInterface.h"
 void __stdcall SigScanner(ArtemisConfig* cfg) // CAUTION! Still remaining on development.

--- a/ArtemisComponents/Arthemida-2/ArtModules/MemoryGuard.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/MemoryGuard.h
@@ -1,7 +1,7 @@
 /*
 	Artemis-2 for MTA Province
 	Target Platform: x32-x86
-	Project by NtKernelMC & holmes0
+	Project by NtKernelMC
 */
 #include "ArtemisInterface.h"
 #include ".../../../../Arthemida-2/ArtUtils/MiniJumper.h"

--- a/ArtemisComponents/Arthemida-2/ArtModules/MemoryScanner.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/MemoryScanner.h
@@ -1,7 +1,7 @@
 /*
 	Artemis-2 for MTA Province
 	Target Platform: x32-x86
-	Project by NtKernelMC & holmes0
+	Project by NtKernelMC
 */
 #include "ArtemisInterface.h"
 void __stdcall MemoryScanner(ArtemisConfig* cfg)
@@ -28,23 +28,6 @@ void __stdcall MemoryScanner(ArtemisConfig* cfg)
 			while (ptr < end && VirtualQuery(ptr, &info[0], sizeof(*info)) == sizeof(*info))
 			{
 				MEMORY_BASIC_INFORMATION* i = &info[0]; 
-				/*if ((DWORD)i->AllocationProtect == PAGE_EXECUTE_WRITECOPY)
-				//0x78BE0000 0x78BE59FF | s: 0x1000 | r: 0x80 - execute copy on write
-				{
-					VirtualLock(i->AllocationBase, i->RegionSize);
-					Utils::LogInFile(ARTEMIS_LOG, "[SHARED MEMORY] WRITE ON COPY!\n");
-					char dMappedName[256]; memset(dMappedName, 0, sizeof(dMappedName));
-					lpGetMappedFileNameA(cfg->CurrProc, i->AllocationBase, dMappedName, sizeof(dMappedName));
-					Utils::LogInFile(ARTEMIS_LOG, "B: 0x%X | S: 0x%X | R: 0x%X | P: %s\n",
-					i->AllocationBase, i->RegionSize, i->AllocationProtect, dMappedName);
-					std::string possible_name = Utils::GetDllName(dMappedName); bool cloacked = false;
-					if (!Utils::IsMemoryInModuledRange((DWORD)i->AllocationBase, possible_name, &cloacked))
-					{
-						if (cloacked) Utils::LogInFile(ARTEMIS_LOG, "[SHARED MEMORY] CLOACKED DETECTION!\n");
-						else Utils::LogInFile(ARTEMIS_LOG, "[SHARED MEMORY] UNMODULED DETECTION!\n");
-					}
-					VirtualUnlock(i->AllocationBase, i->RegionSize);
-				}*/
 				if ((i->State != MEM_FREE && i->State != MEM_RELEASE) && i->Protect & mask)
 				{
 					BYTE complete_sequence = 0; DWORD_PTR foundIAT = 0x0;

--- a/ArtemisComponents/Arthemida-2/ArtModules/ModuleScanner.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/ModuleScanner.h
@@ -1,7 +1,7 @@
 /*
 	Artemis-2 for MTA Province
 	Target Platform: x32-x86
-	Project by NtKernelMC & holmes0
+	Project by NtKernelMC
 */
 #include "ArtemisInterface.h"
 void __stdcall ModuleScanner(ArtemisConfig* cfg)

--- a/ArtemisComponents/Arthemida-2/ArtModules/ThreadScanner.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/ThreadScanner.h
@@ -1,8 +1,40 @@
 /*
 	Artemis-2 for MTA Province
 	Target Platform: x32-x86
-	Project by NtKernelMC & holmes0
+	Project by NtKernelMC
 */
+void __stdcall ThreatReport(ArtemisConfig* cfg, const DWORD &caller, 
+const std::string& possible_name, const std::string& MappedName, bool &cloacked)
+{
+	if (cfg == nullptr) return; if (cfg->callback == nullptr) return;
+	MEMORY_BASIC_INFORMATION mme { 0 }; ARTEMIS_DATA data;
+	VirtualQuery((PVOID)caller, &mme, sizeof(MEMORY_BASIC_INFORMATION));
+	data.baseAddr = (PVOID)caller; data.MemoryRights = mme.AllocationProtect;
+	data.regionSize = mme.RegionSize; data.type = 
+	(cloacked ? DetectionType::ART_DLL_CLOACKING : DetectionType::ART_ILLEGAL_THREAD);
+	data.dllName = cloacked ? possible_name : " "; data.dllPath = cloacked ? MappedName : " ";
+	cfg->callback(&data); cfg->ExcludedThreads.push_back((PVOID)caller);
+}
+void __stdcall LdrInitializeThunk(PCONTEXT Context)
+{
+	PVOID TEP = reinterpret_cast<PVOID>(Context->Eax);
+	PVOID ARG = reinterpret_cast<PVOID>(Context->Ebx);
+	ArtemisConfig* cfg = IArtemisInterface::GetConfig();
+	if (cfg == nullptr) __asm jmp memTramplin
+	char MappedName[256]; memset(MappedName, 0, sizeof(MappedName));
+	lpGetMappedFileNameA(cfg->CurrProc, TEP, MappedName, sizeof(MappedName));
+	std::string possible_name = Utils::GetDllName(MappedName); bool cloacked = false;
+	if (!Utils::IsMemoryInModuledRange((DWORD)TEP, possible_name, &cloacked) &&
+	!Utils::IsVecContain(cfg->ExcludedThreads, TEP))
+	{
+#ifdef ARTEMIS_DEBUG
+		Utils::LogInFile(ARTEMIS_LOG,
+		"[LdrInitializeThunk] Intercepted Thread Initialization! EP: 0x%X | Arg: 0x%X\n", (DWORD)TEP, (DWORD)ARG);
+#endif
+		ThreatReport(cfg, (DWORD)TEP, possible_name, MappedName, cloacked);
+	}
+	__asm jmp memTramplin
+}
 void __stdcall ScanForDllThreads(ArtemisConfig* cfg)
 {
 	if (cfg == nullptr) return;
@@ -12,7 +44,22 @@ void __stdcall ScanForDllThreads(ArtemisConfig* cfg)
 #ifdef ARTEMIS_DEBUG
 	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for ScanForDllThreads! Thread id: %d\n", GetCurrentThreadId());
 #endif
-	while (true) 
+	using tsmMJM = MiniJumper::CustomHooks;
+	memTramplin = tsmMJM::MakeJump((DWORD)callLdrInitializeThunk, (DWORD)LdrInitializeThunk, Prolog, 5);
+	if (memTramplin != NULL) // в дальнейшем весь менеджмент потоками переходит в хук-инициализатора (Callback-Style)
+	{
+#ifdef ARTEMIS_DEBUG
+		Utils::LogInFile(ARTEMIS_LOG, "[INSTALLER] Hook for thread-interception's -> installed!\n");
+#endif
+	}
+	else
+	{
+#ifdef ARTEMIS_DEBUG
+		Utils::LogInFile(ARTEMIS_LOG, "[TROUBLE] By some reasons, hook is not exist in to the list!\n");
+		Utils::LogInFile(ARTEMIS_LOG, "[REPORT] System Error Code: %d\n", GetLastError());
+#endif
+	}
+	while (true)
 	{
 		THREADENTRY32 th32 { 0 }; HANDLE hSnapshot = NULL; th32.dwSize = sizeof(THREADENTRY32);
 		hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
@@ -31,22 +78,16 @@ void __stdcall ScanForDllThreads(ArtemisConfig* cfg)
 						CloseHandle(targetThread); char MappedName[256]; memset(MappedName, 0, sizeof(MappedName));
 						lpGetMappedFileNameA(cfg->CurrProc, (PVOID)tempBase, MappedName, sizeof(MappedName));
 						std::string possible_name = Utils::GetDllName(MappedName); bool cloacked = false;
-						if (!Utils::IsMemoryInModuledRange(tempBase, possible_name, &cloacked) && 
+						if (!Utils::IsMemoryInModuledRange(tempBase, possible_name, &cloacked) &&
 						!Utils::IsVecContain(cfg->ExcludedThreads, (PVOID)tempBase))
 						{
-							MEMORY_BASIC_INFORMATION mme{ 0 }; ARTEMIS_DATA data;
-							VirtualQuery((PVOID)tempBase, &mme, sizeof(MEMORY_BASIC_INFORMATION));
-							data.baseAddr = (PVOID)tempBase; 
-							data.MemoryRights = mme.AllocationProtect; 
-							data.regionSize = mme.RegionSize;
-							data.type = (cloacked ? DetectionType::ART_DLL_CLOACKING : DetectionType::ART_ILLEGAL_THREAD);
-							data.dllName = cloacked ? possible_name : " "; data.dllPath = cloacked ? MappedName : " ";
-							cfg->callback(&data); cfg->ExcludedThreads.push_back((PVOID)tempBase);
+							ThreatReport(cfg, tempBase, possible_name, MappedName, cloacked);
 							break;
 						}
 					}
 				}
-			} while (Thread32Next(hSnapshot, &th32));
+			}
+			while (Thread32Next(hSnapshot, &th32));
 			if (hSnapshot != NULL) CloseHandle(hSnapshot);
 		}
 		Sleep(cfg->ThreadScanDelay);

--- a/ArtemisComponents/Arthemida-2/ArtUtils/MiniJumper.h
+++ b/ArtemisComponents/Arthemida-2/ArtUtils/MiniJumper.h
@@ -8,7 +8,7 @@
 #include <stdio.h>
 namespace MiniJumper
 {
-    PVOID Trampoline = nullptr;
+    static PVOID Trampoline = nullptr;
     class CustomHooks
     {
     public:

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj
@@ -170,6 +170,7 @@
     <ClInclude Include="..\..\Arthemida-2\ArtModules\HeuristicScanner.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtModules\ThreadScanner.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\CRC32.h" />
+    <ClInclude Include="..\..\Arthemida-2\ArtUtils\MiniJumper.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\sigscan.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\Utils.h" />
   </ItemGroup>

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj.filters
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj.filters
@@ -74,5 +74,8 @@
     <ClInclude Include="..\..\Arthemida-2\ArtModules\CServiceMon.h">
       <Filter>Arthemida-2\ArtModules</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Arthemida-2\ArtUtils\MiniJumper.h">
+      <Filter>Arthemida-2\ArtUtils</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ConsoleHost.cpp
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ConsoleHost.cpp
@@ -1,7 +1,7 @@
 /*
 	Artemis-2 for MTA Province
 	Target Platform: x32-x86
-	Project by NtKernelMC & holmes0
+	Project by NtKernelMC
 */
 #ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS


### PR DESCRIPTION
…рок ибо это малозадокументированая нативка которая может менятся от версии винды). Однако переход после первичного сканирования на коллбэк-стиль убирает нагрузку от надобности сканировать потоки т.к данный коллбэк палит потоки которые создаются даже с внешне или с ядра что исключает возможность прожмурить между задержками итераций сканера какой то из потоков который быстро выполнился и затух.