### PR TITLE
Добавлен эвристический модуль анализа на читы.

### DIFF
--- a/ArtemisComponents/Arthemida-2/API/ArtemisComponents.cpp
+++ b/ArtemisComponents/Arthemida-2/API/ArtemisComponents.cpp
@@ -105,12 +105,12 @@ ArtemisConfig* __stdcall IArtemisInterface::GetConfig()
 	return i_art->g_cfg; 
 }
 /////////////////////////// Protection Modules //////////////////////////////////////////////////////////////
+#include "../../Arthemida-2/ArtModules/HeuristicScanner.h"
 #include "../../Arthemida-2/ArtModules/ThreadScanner.h"
 #include "../../Arthemida-2/ArtModules/AntiFakeLaunch.h"
 #include "../../Arthemida-2/ArtModules/ModuleScanner.h"
 #include "../../Arthemida-2/ArtModules/MemoryScanner.h"
 #include "../../Arthemida-2/ArtModules/MemoryGuard.h"
-#include "../../Arthemida-2/ArtModules/HeuristicScanner.h"
 #include "../../Arthemida-2/ArtModules/CServiceMon.h"
 IArtemisInterface* __stdcall IArtemisInterface::InstallArtemisMonitor(ArtemisConfig* cfg)
 {

--- a/ArtemisComponents/Arthemida-2/API/ArtemisTypes.h
+++ b/ArtemisComponents/Arthemida-2/API/ArtemisTypes.h
@@ -43,6 +43,7 @@ namespace ArtemisData
 		HANDLE CurrProc = nullptr;
 		std::vector<HANDLE> OwnThreads;
 		ArtemisCallback callback = nullptr;
+		std::vector<std::string> AllowedPackedModules;
 		// anticheat controller options
 		bool DetectThreads = false;
 		bool DetectModules = false;

--- a/ArtemisComponents/Arthemida-2/ArtUtils/Utils.h
+++ b/ArtemisComponents/Arthemida-2/ArtUtils/Utils.h
@@ -37,6 +37,8 @@
 #include <conio.h>
 #include <intrin.h>
 #include <cwctype>
+#include <dbghelp.h>
+#pragma comment(lib, "dbghelp.lib")
 #pragma intrinsic(_ReturnAddress)
 #include "../../Arthemida-2/ArtUtils/CRC32.h"
 #include "../../Arthemida-2/ArtUtils/sigscan.h"

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ConsoleHost.cpp
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ConsoleHost.cpp
@@ -39,6 +39,10 @@ void __stdcall ArthemidaCallback(ARTEMIS_DATA* artemis)
 		\rPath: %s\n\n", artemis->baseAddr, artemis->regionSize, artemis->MemoryRights,
 		artemis->dllName.c_str(), artemis->dllPath.c_str());
 		break;
+	case DetectionType::ART_PROTECTOR_PACKER:
+		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected Packed DLL! Base: 0x%X | Image Size: 0x%X | DllName: %s\n\
+		\rPath: %s\n\n", artemis->baseAddr, artemis->regionSize, artemis->dllName.c_str(), artemis->dllPath.c_str());
+		break;
 	case DetectionType::ART_FAKE_LAUNCHER:
 		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected Startup from Fake Launcher!\n");
 		break;
@@ -112,6 +116,8 @@ int main()
 	("\x5B\x64\x62\x67\x5D\x20\x72\x65\x76\x65\x72\x74\x65\x64\x20\x25\x77\x5A\x20\x73\x77\x61\x70", "xxxxxxxxxxxxxxxxxxxxxxx")));
 	//todo cfg.PriorityDriverNames
 
+
+	cfg.AllowedPackedModules.push_back("netc.dll");
 	//cfg.DetectBySignature = true; cfg.PatternScanDelay = 1000; 
 	//cfg.IllegalPatterns.insert(std::pair<std::string, std::tuple<const char*, const char*>>
 	//(hack_name, std::make_tuple(pattern, mask))); // must be incapsulated
@@ -134,7 +140,7 @@ int main()
 		// test detection of illegal calls (return addresses checking)
 		//RetTest::TestStaticMethod();
 		//testObj.TestMemberMethod(); 
-		//LoadLibraryA("test.dll"); // For heuristic-scans on future & excluding false-positives in ProxyDLL detection.
+		LoadLibraryA("test.dll"); // For heuristic-scans on future & excluding false-positives in ProxyDLL detection.
 	}
 	else Utils::LogInFile(ARTEMIS_LOG, "[ARTEMIS-2] Failure on start :( Last error code: %d\n", GetLastError());
 	while (true) 

--- a/ArtemisComponents/ConsoleTests/InvasionTerminal/AssaultConsole.cpp
+++ b/ArtemisComponents/ConsoleTests/InvasionTerminal/AssaultConsole.cpp
@@ -24,9 +24,9 @@ int main()
 	if (procGate.SafeProcess<const wchar_t*, LPSTARTUPINFOW>
 	(L"ArtemisHost.exe", L"", NULL, NULL, TRUE, 0, NULL, NULL, &info, &processInfo))
 	{
-		char tst_dll[256]; memset(tst_dll, 0, sizeof(tst_dll));
+		/*char tst_dll[256]; memset(tst_dll, 0, sizeof(tst_dll));
 		char* cvr = _getcwd(tst_dll, sizeof(tst_dll)); strcat(tst_dll, "\\test.dll");
-		MmapDLL(processInfo.hProcess, tst_dll);
+		MmapDLL(processInfo.hProcess, tst_dll);*/
 		printf("Process created. Press any key to exit.\n");
 		int anykey = getchar(); ExitProcess(0x0);
 	}


### PR DESCRIPTION
(Детект эвристики упакованных или запротекченных модулей, так же добавлен дефолт вайтлист ибо в мта как минимум нетс сюда попадет). На виндузятные не будет ругать, только свои под протектом в конфиге выставлять в вектор алловед листинга.