### PR TITLE
(Разверни для подробной информации)

### DIFF
--- a/ArtemisComponents/Arthemida-2/API/ArtemisTypes.h
+++ b/ArtemisComponents/Arthemida-2/API/ArtemisTypes.h
@@ -22,7 +22,11 @@ namespace ArtemisData
 		ART_PROTECTOR_PACKER,
 		ART_HACK_STRING_FOUND,
 		ART_SIGNATURE_DETECT,
-		ART_ILLEGAL_SERVICE
+		ART_ILLEGAL_SERVICE,
+		ART_MEMORY_PROTECT_VIOLATION,
+		ART_MEMORY_PROTECT_MAYBE_VIOLATION, // maybe a false-positive, should be dumped without taking action
+		ART_THREAD_FLAGS_CHANGED,
+		ART_THREAD_SUSPENDED
 	};
 	struct ARTEMIS_DATA
 	{
@@ -49,11 +53,12 @@ namespace ArtemisData
 		bool DetectModules = false;
 		bool DetectFakeLaunch = false;
 		bool DetectManualMap = false;
-		bool DetectMemoryPatch = false;
+		bool MemoryGuard = false;
 		bool DetectBySignature = false;
 		bool DetectPacking = false;
 		bool DetectByString = false;
 		bool ServiceMon = false;
+		bool ThreadGuard = false;
 		// anti-repeatable start for scanners
 		bool ThreadScanner = false;
 		bool ModuleScanner = false;
@@ -65,6 +70,7 @@ namespace ArtemisData
 		DWORD MemoryScanDelay = 0x0;
 		DWORD MemoryGuardScanDelay = 0x0;
 		DWORD ServiceMonDelay = 0x0;
+		DWORD ThreadGuardDelay = 0x0;
 		// additional settings & stuff
 		std::vector<PVOID> ExcludedThreads;
 		std::vector<PVOID> ExcludedModules;

--- a/ArtemisComponents/Arthemida-2/ArtModules/ArtThreading.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/ArtThreading.h
@@ -1,0 +1,145 @@
+/*
+	Artemis-2 for MTA Province
+	Target Platform: x32-x86
+	Project by NtKernelMC & holmes0
+*/
+/**
+* Assignee: holmes0
+* Done:
+*		Protect threads with termination-preventing flags (BSOD on manual termination)
+*		Protect threads with suspension-preventing flags on Win10 19H1+ (ignores suspension requests)
+*
+* TBD in future parts:
+*		Thread intercommunication, one thread get suspended/terminated - every other thread knows about it.
+*		Thread communication with main MTA thread (if someone kills/suspends all threads, main thread will take care of it)
+*/
+#include "ArtemisInterface.h"
+#pragma comment(lib, "Version.lib")
+using namespace ArtemisData;
+
+namespace ArtThreading
+{
+	typedef NTSTATUS(NTAPI* pfnNtCreateThreadEx)
+		(
+			OUT PHANDLE hThread,
+			IN ACCESS_MASK DesiredAccess,
+			IN PVOID ObjectAttributes,
+			IN HANDLE ProcessHandle,
+			IN PVOID lpStartAddress,
+			IN PVOID lpParameter,
+			IN ULONG Flags,
+			IN SIZE_T StackZeroBits,
+			IN SIZE_T SizeOfStackCommit,
+			IN SIZE_T SizeOfStackReserve,
+			OUT PVOID lpBytesBuffer);
+
+	typedef NTSTATUS(NTAPI* pfnNtSetInformationThread)(
+		HANDLE ThreadHandle,
+		Utils::THREAD_INFORMATION_CLASS ThreadInformationClass,
+		PVOID ThreadInformation,
+		ULONG ThreadInformationLength
+		);
+
+
+#define THREAD_CREATE_FLAGS_BYPASS_PROCESS_FREEZE 0x40
+#define THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER 0x00000004
+
+	bool Is19H1OrGreater()
+	{
+		DWORD dwHandle;
+		DWORD cbInfo = GetFileVersionInfoSizeExW(FILE_VER_GET_NEUTRAL, L"kernel32.dll", &dwHandle);
+		std::vector<char> buffer(cbInfo);
+		GetFileVersionInfoExW(FILE_VER_GET_NEUTRAL, L"kernel32.dll", dwHandle, buffer.size(), &buffer[0]);
+
+		void* p = nullptr;
+		UINT size = 0;
+		VerQueryValueW(buffer.data(), L"\\", &p, &size);
+		
+		VS_FIXEDFILEINFO* vsFixedFileInfo = (VS_FIXEDFILEINFO*)p;
+		if (HIWORD(vsFixedFileInfo->dwFileVersionLS) > 18362) return true;
+		return false;
+	}
+
+	HANDLE CreateProtectedThread(PVOID lpStartAddress, PVOID lpParameter)
+	{
+		pfnNtCreateThreadEx fnNtCreateThreadEx = (pfnNtCreateThreadEx)Utils::RuntimeIatResolver("ntdll.dll", "NtCreateThreadEx");
+		if (fnNtCreateThreadEx == NULL) return INVALID_HANDLE_VALUE;
+
+		HANDLE hThread = NULL;
+		
+		if (Is19H1OrGreater())
+		{
+#ifdef ARTEMIS_DEBUG
+			fnNtCreateThreadEx(&hThread, MAXIMUM_ALLOWED, nullptr, GetCurrentProcess(), lpStartAddress, lpParameter, 0, 0, 0, 0, nullptr);
+#else
+			fnNtCreateThreadEx(&hThread, MAXIMUM_ALLOWED, nullptr, GetCurrentProcess(), lpStartAddress, lpParameter, THREAD_CREATE_FLAGS_BYPASS_PROCESS_FREEZE | THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER, 0, 0, 0, nullptr);
+#endif
+		}
+		else
+		{
+#ifdef ARTEMIS_DEBUG
+			fnNtCreateThreadEx(&hThread, MAXIMUM_ALLOWED, nullptr, GetCurrentProcess(), lpStartAddress, lpParameter, 0, 0, 0, 0, nullptr);
+#else
+			fnNtCreateThreadEx(&hThread, MAXIMUM_ALLOWED, nullptr, GetCurrentProcess(), lpStartAddress, lpParameter, THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER, 0, 0, 0, nullptr);
+#endif
+		}
+
+		Utils::SetPrivilege(NULL, SE_DEBUG_NAME, TRUE);
+
+		pfnNtSetInformationThread NtSetInformationThread = (pfnNtSetInformationThread)Utils::RuntimeIatResolver("ntdll.dll", "NtSetInformationThread");
+		bool Enable = true;
+#ifndef ARTEMIS_DEBUG // Dangerous protection (BSOD on manual thread termination only)
+		NTSTATUS ntThreadBreakOnTermination = NtSetInformationThread(hThread, Utils::ThreadBreakOnTermination, &Enable, sizeof(Enable));
+		if (ntThreadBreakOnTermination != 0) printf("[ERROR/ArtThreading] Failed to set ThreadBreakOnTermination! NTSTATUS: 0x%08X\n", ntThreadBreakOnTermination);
+#endif
+#ifdef ARTEMIS_DEBUG
+		printf("[ArtThreading] Created protected thread handle 0x%08X\n", (DWORD)lpStartAddress);
+#endif
+
+		return hThread;
+	}
+}
+
+namespace ThreadGuard
+{
+	typedef NTSTATUS(NTAPI* pfnNtQueryInformationThread)(
+		HANDLE ThreadHandle,
+		Utils::THREAD_INFORMATION_CLASS ThreadInformationClass,
+		PVOID ThreadInformation,
+		ULONG ThreadInformationLength,
+		PULONG ReturnLength
+	);
+
+	void __stdcall ThreadScanner(ArtemisConfig* cfg)
+	{
+		pfnNtQueryInformationThread fnNtQueryInformationThread = (pfnNtQueryInformationThread)Utils::RuntimeIatResolver("ntdll.dll", "NtQueryInformationThread");
+		if (!fnNtQueryInformationThread) return;
+
+		auto CallDetect = [&cfg](HANDLE hThread)
+		{
+			ARTEMIS_DATA data;
+			data.type = DetectionType::ART_THREAD_FLAGS_CHANGED;
+			data.baseAddr = (PVOID)hThread;
+			cfg->callback(&data);
+		};
+
+		while (true)
+		{
+			for (auto& thread : cfg->OwnThreads)
+			{
+				bool bCheck = FALSE;
+#ifndef ARTEMIS_DEBUG
+				NTSTATUS ntStatTBOT = fnNtQueryInformationThread(thread, Utils::ThreadBreakOnTermination, &bCheck, sizeof(bCheck), 0);
+				if (ntStat != 0) printf("[ERROR/ThreadGuard] Failed to query thread info! NTSTATUS: %08X\n", ntStatTBOT);
+				if (!bCheck) CallDetect(thread);
+
+				NTSTATUS ntStatTHFD = fnNtQueryInformationThread(thread, Utils::ThreadHideFromDebugger, &bCheck, sizeof(bCheck), 0);
+				if (ntStatTHFD != 0) printf("[ERROR/ThreadGuard] Failed to query thread info! NTSTATUS: %08X\n", ntStatTHFD);
+				if (!bCheck) CallDetect(thread);
+#endif
+			}
+
+			Sleep(cfg->ThreadGuardDelay);
+		}
+	}
+}

--- a/ArtemisComponents/Arthemida-2/ArtModules/MemoryGuard.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/MemoryGuard.h
@@ -3,37 +3,58 @@
 	Target Platform: x32-x86
 	Project by NtKernelMC & holmes0
 */
+/**
+* Assignee: holmes0
+* Done: 
+*		Hook NtProtectVirtualMemory and block changes to executable memory
+*		Keep constantly updated list of memory page rights in order to detect any external modifications
+*			This still allows fast external protection changing and writing, impossible to perfectly protect from usermode.
+* 
+*		(FIXED) Bug: Page containing NtProtectVirtualMemory remains with PAGE_READWRITE_EXECUTE rights for hook library to remove and place hook back (consider switching to another library).
+*
+* TBD:
+*		WIP Enhancement: Multithreaded (faster) scanning to detect and prevent patching.
+*/
 #include "ArtemisInterface.h"
-#include ".../../../../Arthemida-2/ArtUtils/MiniJumper.h"
-void __thiscall IArtemisInterface::ConfirmLegitReturn(const char* function_name, PVOID return_address)
+
+std::map<DWORD, DWORD> mpProtectionList;
+
+typedef NTSTATUS(__stdcall* pNtProtectVirtualMemory)(HANDLE ProcessHandle, PVOID* BaseAddress, PULONG NumberOfBytesToProtect, ULONG NewAccessProtection, PULONG OldAccessProtection);
+pNtProtectVirtualMemory ptrNtProtectVirtualMemory;
+pNtProtectVirtualMemory ptrOriginalNtProtectVirtualMemory;
+
+NTSTATUS __stdcall hkNtProtectVirtualMemory(HANDLE ProcessHandle, PVOID* BaseAddress, PULONG NumberOfBytesToProtect, ULONG NewAccessProtection, PULONG OldAccessProtection)
 {
-	if (function_name == nullptr || return_address == nullptr) return; ArtemisConfig* cfg = GetConfig();
-	if (cfg == nullptr) return; static std::vector<std::string> allowedModules = 
-	{ "client.dll", "multiplayer_sa.dll", "game_sa.dll", "core.dll", "gta_sa.exe", "proxy_sa.exe" };
-	if (!Utils::IsInModuledAddressSpace(return_address, allowedModules) && 
-	!Utils::IsVecContain(cfg->ExcludedMethods, return_address))
+#define CALL_ORIG(a, b, c, d, e) ptrOriginalNtProtectVirtualMemory(a, b, c, d, e);
+
+	ULONG ulOldProt;
+	NTSTATUS result = CALL_ORIG(ProcessHandle, BaseAddress, NumberOfBytesToProtect, NewAccessProtection, &ulOldProt);
+	
+	if (ulOldProt & PAGE_EXECUTE_READWRITE)
 	{
-		char MappedName[256]; memset(MappedName, 0, sizeof(MappedName));
-		lpGetMappedFileNameA(GetCurrentProcess(), (PVOID)return_address, MappedName, sizeof(MappedName));
-		///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-		MEMORY_BASIC_INFORMATION mme{ 0 }; ARTEMIS_DATA data; 
-		 std::string DllName = Utils::GetDllName(MappedName);
-		VirtualQuery(return_address, &mme, sizeof(MEMORY_BASIC_INFORMATION));
-		data.baseAddr = (LPVOID)return_address; 
-		data.MemoryRights = mme.AllocationProtect; 
-		data.regionSize = mme.RegionSize;
-		data.type = DetectionType::ART_RETURN_ADDRESS;
-		data.dllName = DllName; data.dllPath = MappedName; 
-		if (cfg != nullptr)
-		{
-			cfg->callback(&data); cfg->ExcludedMethods.push_back(return_address); 
-#ifdef ARTEMIS_DEBUG
-			Utils::LogInFile(ARTEMIS_LOG, "\nReturned from %s function to 0x%X\n", function_name, return_address);
-#endif
-		}
+		CALL_ORIG(ProcessHandle, BaseAddress, NumberOfBytesToProtect, PAGE_EXECUTE_READ, &ulOldProt);
+		*OldAccessProtection = PAGE_EXECUTE_READ;
+		return result;
 	}
+	
+	if (ulOldProt & (PAGE_EXECUTE | PAGE_EXECUTE_READ))
+	{
+		CALL_ORIG(ProcessHandle, BaseAddress, NumberOfBytesToProtect, ulOldProt, &ulOldProt);
+		*OldAccessProtection = ulOldProt;
+		return 0xC0000022; // STATUS_ACCESS_DENIED
+	}
+
+	if (NewAccessProtection & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY))
+	{
+		CALL_ORIG(ProcessHandle, BaseAddress, NumberOfBytesToProtect, ulOldProt, &ulOldProt);
+		*OldAccessProtection = ulOldProt;
+		return 0xC0000022; // STATUS_ACCESS_DENIED
+	}
+
+	return result;
 }
-void __stdcall MemoryGuardScanner(ArtemisConfig* cfg) // On tehnical work
+
+void __stdcall MemoryGuardScanner(ArtemisConfig* cfg)
 {
 	if (cfg == nullptr)
 	{
@@ -45,36 +66,84 @@ void __stdcall MemoryGuardScanner(ArtemisConfig* cfg) // On tehnical work
 #ifdef ARTEMIS_DEBUG
 	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for MemoryGuardScanner! Thread id: %d\n", GetCurrentThreadId());
 #endif
-	auto ReverseDelta = [](DWORD_PTR CurrentAddress, DWORD Delta, size_t InstructionLength, bool bigger = false) -> DWORD_PTR
+
+	SetProcessDEPPolicy(PROCESS_DEP_ENABLE);
+
+	ptrNtProtectVirtualMemory = (pNtProtectVirtualMemory)Utils::RuntimeIatResolver("ntdll.dll", "NtProtectVirtualMemory");
+	
+	BYTE* Trampoline = (BYTE*)VirtualAlloc(NULL, 10, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE); // don't change to new/malloc!
+	memcpy(Trampoline, ptrNtProtectVirtualMemory, 5);
+	Trampoline[5] = 0xE9;
+	DWORD dwRelJmpBack = ((DWORD)ptrNtProtectVirtualMemory + 5) - (DWORD)&Trampoline[5] - 5;
+	memcpy(Trampoline + 6, &dwRelJmpBack, 4);
+	DWORD dwOldProt;
+	VirtualProtect(Trampoline, 10, PAGE_EXECUTE_READ, &dwOldProt);
+	ptrOriginalNtProtectVirtualMemory = (pNtProtectVirtualMemory)Trampoline;
+
+	DWORD dwRelAddr = (((DWORD)&hkNtProtectVirtualMemory) - (DWORD)ptrNtProtectVirtualMemory) - 5;
+	BYTE patch[5] = { 0xE9, 0x00, 0x00, 0x00, 0x00 };
+	memcpy(&patch[1], &dwRelAddr, 4);
+	VirtualProtect(ptrNtProtectVirtualMemory, 5, PAGE_EXECUTE_READWRITE, &dwOldProt);
+	memcpy(ptrNtProtectVirtualMemory, patch, 5);
+	ULONG ulBytesToProtect = 5;
+	ptrOriginalNtProtectVirtualMemory(GetCurrentProcess(), (void**)&ptrOriginalNtProtectVirtualMemory, &ulBytesToProtect, PAGE_EXECUTE_READ, &dwOldProt);
+
+	auto CallDetect = [&cfg](void* ptrBase, DWORD dwLength, bool bPossibleFalsePositive = false)
 	{
-		if (bigger) return ((CurrentAddress + (Delta + InstructionLength)) - 0xFFFFFFFE);
-		return CurrentAddress + (Delta + InstructionLength);
+		ARTEMIS_DATA data;
+		data.baseAddr = ptrBase;
+		data.regionSize = dwLength;
+		if (bPossibleFalsePositive) data.type = DetectionType::ART_MEMORY_PROTECT_MAYBE_VIOLATION;
+		else data.type = DetectionType::ART_MEMORY_PROTECT_VIOLATION;
+
+		cfg->callback(&data);
 	};
+
+	SYSTEM_INFO sysInfo{ 0 }; 
+	GetNativeSystemInfo(&sysInfo);
+	SIZE_T MaxAddr = (DWORD)sysInfo.lpMaximumApplicationAddress - (DWORD)sysInfo.lpMinimumApplicationAddress;
 	while (true)
 	{
-#ifndef _CONSOLE
-		if (!GetModuleHandleA("client.dll")) break;
-#endif
-		if (!cfg->DetectMemoryPatch) break;
-		for (const auto& it : cfg->HooksList)
+		if (!cfg->MemoryGuard) return;
+
+		auto WatchMemoryAllocations = [&, cfg]
+		(const void* ptr, size_t length, MEMORY_BASIC_INFORMATION* info, int size)
 		{
-#ifndef _CONSOLE
-			if (!GetModuleHandleA("client.dll")) break;
-#endif
-			DWORD Delta = NULL; memcpy(&Delta, (PVOID)((DWORD)it.second + 0x1), 4);
-			DWORD_PTR DestinationAddr = ReverseDelta((DWORD_PTR)it.second, Delta, 5);
-			if (*(BYTE*)it.second != 0xE9 || (*(BYTE*)it.second == 0xE9 && DestinationAddr != (DWORD)it.first))
+			if (ptr == nullptr || info == nullptr) return;
+			const void* end = (const void*)((const char*)ptr + length);
+			while (ptr < end && VirtualQuery(ptr, &info[0], sizeof(*info)) == sizeof(*info))
 			{
-				if (!Utils::IsVecContain(cfg->ExcludedPatches, it.second))
+				//printf("[Memory Guard] Working with ptr %X %X\n", (DWORD)ptr, ((MEMORY_BASIC_INFORMATION*)&info[0])->BaseAddress);
+				MEMORY_BASIC_INFORMATION* i = &info[0];
+				if ((i->State != MEM_FREE && i->State != MEM_RELEASE))
 				{
-					ARTEMIS_DATA data; data.baseAddr = it.second; 
-					data.MemoryRights = PAGE_EXECUTE_READWRITE; data.regionSize = 0x5;
-					data.dllName = "client.dll"; data.dllPath = "MTA\\mods\\deadmatch\\client.dll";
-					data.type = DetectionType::ART_MEMORY_CHANGED;
-					cfg->callback(&data); cfg->ExcludedPatches.push_back(it.second);
+					DWORD dwBase = (DWORD)ptr;
+					if (i->Protect & (PAGE_EXECUTE_READWRITE) && !(dwBase < (DWORD)ptrNtProtectVirtualMemory && ((DWORD)ptrNtProtectVirtualMemory - dwBase) < i->RegionSize))
+					{
+						DWORD dwOldProt;
+						VirtualProtect(i->BaseAddress, i->RegionSize, PAGE_EXECUTE_READ, &dwOldProt);
+						CallDetect((void*)ptr, i->RegionSize, true);
+					}
+
+					if (mpProtectionList.find(dwBase) == mpProtectionList.end())
+					{
+						mpProtectionList[dwBase] = i->Protect;
+					}
+					else if(i->Protect != mpProtectionList[dwBase])
+					{
+						if (i->Protect & (PAGE_EXECUTE | PAGE_EXECUTE_READ) && !(mpProtectionList[dwBase] & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE)))
+							CallDetect((void*)ptr, i->RegionSize);
+
+						mpProtectionList[dwBase] = i->Protect;
+					}
 				}
+				ptr = (const void*)((const char*)(i->BaseAddress) + i->RegionSize);
 			}
-		}
+		};
+		MEMORY_BASIC_INFORMATION mbi{ 0 };
+		WatchMemoryAllocations(sysInfo.lpMinimumApplicationAddress, MaxAddr,
+			&mbi, sizeof(MEMORY_BASIC_INFORMATION));
+
 		Sleep(cfg->MemoryGuardScanDelay);
 	}
 }

--- a/ArtemisComponents/Arthemida-2/ArtModules/ModuleScanner.h
+++ b/ArtemisComponents/Arthemida-2/ArtModules/ModuleScanner.h
@@ -89,8 +89,8 @@ void __stdcall ModuleScanner(ArtemisConfig* cfg)
 						{
 							static SigScan scn; DWORD sgAddr = scn.FindPattern(NameOfDLL.c_str(),
 							std::get<0>(sg.second).c_str()/*"\x8D\x45\xF4\x64\xA3\x00\x00\x00\x00\x68"*/, std::get<1>(sg.second).c_str());
-							printf("[SIG WALKER] Name: %s | Pattern: %s | Mask: %s | Len: %d\n", NameOfDLL.c_str(),
-							std::get<0>(sg.second).c_str(), std::get<1>(sg.second).c_str(), std::get<0>(sg.second).length());
+							//printf("[SIG WALKER] Name: %s | Pattern: %s | Mask: %s | Len: %d\n", NameOfDLL.c_str(),
+							//std::get<0>(sg.second).c_str(), std::get<1>(sg.second).c_str(), std::get<0>(sg.second).length());
 							if (sgAddr != NULL)
 							{
 								ModuleThreatReport(it, szFileName, NameOfDLL, DetectionType::ART_SIGNATURE_DETECT, sg.first);

--- a/ArtemisComponents/Arthemida-2/ArtModules/ThreadedMemoryGuard_WIP.h_unused
+++ b/ArtemisComponents/Arthemida-2/ArtModules/ThreadedMemoryGuard_WIP.h_unused
@@ -1,0 +1,178 @@
+/*
+	Artemis-2 for MTA Province
+	Target Platform: x32-x86
+	Project by NtKernelMC & holmes0
+*/
+/**
+* Assignee: holmes0
+* Done: 
+*		Hook NtProtectVirtualMemory and block changes to executable memory
+*		Keep constantly updated list of memory page rights in order to detect any external modifications (+debugger)
+*			This still allows fast external protection changing and writing, impossible to perfectly protect from usermode.
+*
+* In progress:
+*		Try multithreaded fast scanning of executable page rights to detect and prevent/break patching attempts (+debugger).
+*/
+#include "ArtemisInterface.h"
+//#include ".../../../../Arthemida-2/ArtUtils/MiniJumper.h"
+#include "../ArtUtils/urmem.hpp"
+
+struct mpDescriptor
+{
+	DWORD dwAddress;
+	DWORD dwSize;
+	DWORD dwProtection;
+};
+std::map<DWORD, mpDescriptor> mpProtectionList;
+
+urmem::hook hook_NPVM;
+typedef NTSTATUS(__stdcall* pNtProtectVirtualMemory)(HANDLE ProcessHandle, PVOID* BaseAddress, PULONG NumberOfBytesToProtect, ULONG NewAccessProtection, PULONG OldAccessProtection);
+static pNtProtectVirtualMemory ptrNtProtectVirtualMemory;
+
+NTSTATUS __stdcall hkNtProtectVirtualMemory(HANDLE ProcessHandle, PVOID* BaseAddress, PULONG NumberOfBytesToProtect, ULONG NewAccessProtection, PULONG OldAccessProtection)
+{
+#define CALL_ORIG(a, b, c, d, e) hook_NPVM.call<urmem::calling_convention::stdcall, NTSTATUS>(a, b, c, d, e);
+
+	ULONG ulOldProt;
+	NTSTATUS result = CALL_ORIG(ProcessHandle, BaseAddress, NumberOfBytesToProtect, NewAccessProtection, &ulOldProt);
+	
+	if (ulOldProt & PAGE_EXECUTE_READWRITE)
+	{
+		CALL_ORIG(ProcessHandle, BaseAddress, NumberOfBytesToProtect, PAGE_EXECUTE_READ, &ulOldProt);
+		*OldAccessProtection = PAGE_EXECUTE_READ;
+		return result;
+	}
+	
+	if (ulOldProt & (PAGE_EXECUTE | PAGE_EXECUTE_READ))
+	{
+		CALL_ORIG(ProcessHandle, BaseAddress, NumberOfBytesToProtect, ulOldProt, &ulOldProt);
+		*OldAccessProtection = ulOldProt;
+		return 0xC0000022; // STATUS_ACCESS_DENIED
+	}
+
+	if (NewAccessProtection & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY))
+	{
+		CALL_ORIG(ProcessHandle, BaseAddress, NumberOfBytesToProtect, ulOldProt, &ulOldProt);
+		*OldAccessProtection = ulOldProt;
+		return 0xC0000022; // STATUS_ACCESS_DENIED
+	}
+
+	return result;
+}
+
+namespace MemoryGuard
+{
+	void FillMpProtectionList()
+	{
+		SYSTEM_INFO sysInfo{ 0 };
+		GetNativeSystemInfo(&sysInfo);
+		SIZE_T MaxAddr = (DWORD)sysInfo.lpMaximumApplicationAddress - (DWORD)sysInfo.lpMinimumApplicationAddress;
+
+		MEMORY_BASIC_INFORMATION mbi{ 0 };
+
+		const void* ptr = sysInfo.lpMinimumApplicationAddress;
+		const void* end = (const void*)((const char*)ptr + MaxAddr);
+		while (ptr < end && VirtualQuery(ptr, &mbi, sizeof(mbi)) == sizeof(mbi))
+		{
+			MEMORY_BASIC_INFORMATION* i = &mbi;
+			if ((i->State != MEM_FREE && i->State != MEM_RELEASE))
+			{
+				DWORD dwBase = (DWORD)ptr;
+				if (mpProtectionList.find(dwBase) == mpProtectionList.end())
+				{
+					mpProtectionList[dwBase].dwProtection = i->Protect;
+					mpProtectionList[dwBase].dwAddress = dwBase;
+				}
+			}
+			ptr = (const void*)((const char*)(i->BaseAddress) + i->RegionSize);
+		}
+	}
+
+	void Worker(unsigned int uiStartIndex, unsigned int uiCount, ArtemisConfig* cfg)
+	{
+		auto CallDetect = [&cfg](void* ptrBase, DWORD dwLength, bool bPossibleFalsePositive = false)
+		{
+			ARTEMIS_DATA data;
+			data.baseAddr = ptrBase;
+			data.regionSize = dwLength;
+			if (bPossibleFalsePositive) data.type = DetectionType::ART_MEMORY_PROTECT_MAYBE_VIOLATION;
+			else data.type = DetectionType::ART_MEMORY_PROTECT_VIOLATION;
+
+			cfg->callback(&data);
+		};
+
+		while (true)
+		{
+			while ()
+			{
+				if ((i->State != MEM_FREE && i->State != MEM_RELEASE))
+				{
+					DWORD dwBase = (DWORD)ptr;
+					if (i->Protect & (PAGE_EXECUTE_READWRITE) && !(dwBase < (DWORD)ptrNtProtectVirtualMemory && ((DWORD)ptrNtProtectVirtualMemory - dwBase) < i->RegionSize))
+					{
+						DWORD dwOldProt;
+						VirtualProtect(i->BaseAddress, i->RegionSize, PAGE_EXECUTE_READ, &dwOldProt);
+						CallDetect((void*)ptr, i->RegionSize, true);
+					}
+
+					if (mpProtectionList.find(dwBase) == mpProtectionList.end())
+					{
+						mpProtectionList[dwBase] = i->Protect;
+					}
+					else if (i->Protect != mpProtectionList[dwBase])
+					{
+						if (i->Protect & (PAGE_EXECUTE | PAGE_EXECUTE_READ) && !(mpProtectionList[dwBase] & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE)))
+							CallDetect((void*)ptr, i->RegionSize);
+
+						mpProtectionList[dwBase] = i->Protect;
+					}
+				}
+			}
+
+			Sleep(cfg->MemoryGuardScanDelay);
+		}
+	}
+}
+
+void __stdcall MemoryGuardScanner(ArtemisConfig* cfg)
+{
+	if (cfg == nullptr)
+	{
+#ifdef ARTEMIS_DEBUG
+		Utils::LogInFile(ARTEMIS_LOG, "[ERROR] Passed null pointer to MemoryGuardScanner\n");
+#endif
+		return;
+	}
+#ifdef ARTEMIS_DEBUG
+	Utils::LogInFile(ARTEMIS_LOG, "[INFO] Created async thread for MemoryGuardScanner! Thread id: %d\n", GetCurrentThreadId());
+#endif
+
+	SetProcessDEPPolicy(PROCESS_DEP_ENABLE);
+
+	ptrNtProtectVirtualMemory = (pNtProtectVirtualMemory)Utils::RuntimeIatResolver("ntdll.dll", "NtProtectVirtualMemory");
+	hook_NPVM.install((DWORD)ptrNtProtectVirtualMemory, urmem::get_func_addr(&hkNtProtectVirtualMemory));
+
+	//DWORD dwOld;
+	//VirtualProtect(ptrNtProtectVirtualMemory, 0x20, PAGE_EXECUTE, &dwOld);
+
+	auto CallDetect = [&cfg](void* ptrBase, DWORD dwLength, bool bPossibleFalsePositive = false)
+	{
+		ARTEMIS_DATA data;
+		data.baseAddr = ptrBase;
+		data.regionSize = dwLength;
+		if (bPossibleFalsePositive) data.type = DetectionType::ART_MEMORY_PROTECT_MAYBE_VIOLATION;
+		else data.type = DetectionType::ART_MEMORY_PROTECT_VIOLATION;
+
+		cfg->callback(&data);
+	};
+
+	MemoryGuard::FillMpProtectionList();
+	std::vector<int> vecObjectsForThread = Utils::SplitObjectsForThreading(mpProtectionList.size(), 4);
+
+	for (auto& iObjectCount : vecObjectsForThread)
+	{
+		static unsigned int uiCurrentIndex = 0;
+		std::thread(MemoryGuard::Worker, uiCurrentIndex, iObjectCount, cfg).detach();
+		uiCurrentIndex += iObjectCount;
+	}
+}

--- a/ArtemisComponents/Arthemida-2/ArtUtils/Utils.h
+++ b/ArtemisComponents/Arthemida-2/ArtUtils/Utils.h
@@ -93,7 +93,8 @@ public:
 		ThreadPriorityBoost,
 		ThreadSetTlsArrayAddress,
 		ThreadIsIoPending,
-		ThreadHideFromDebugger
+		ThreadHideFromDebugger,
+		ThreadBreakOnTermination
 	} THREAD_INFORMATION_CLASS, *PTHREAD_INFORMATION_CLASS;
 	static BOOL SetPrivilege(HANDLE hToken, LPCTSTR lpszPrivilege, BOOL bEnablePrivilege)
 	{
@@ -376,5 +377,27 @@ public:
 			}
 		}
 #endif  
+	}
+
+	/**
+	*  Example: splits 1500 into vector of 500, 500, 500 for 3 threads
+	*  Example 2: splits 1631 into vector of 407, 408, 408, 408 for 4 threads
+	*  In case if objects won't evenly split, more are given to last threads and less to first
+	*/
+	static std::vector<int> SplitObjectsForThreading(unsigned int uiObjectCount, unsigned int uiThreadCount)
+	{
+		std::vector<int> parts;
+
+		for (int i = 0; i < uiThreadCount; i++)
+		{
+			parts.push_back(uiObjectCount / uiThreadCount);
+		}
+
+		for (int i = 0; i < (uiObjectCount % uiThreadCount); i++)
+		{
+			*(parts.rbegin() + i) += 1;
+		}
+
+		return parts;
 	}
 };

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj
@@ -112,6 +112,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <EnableModules>false</EnableModules>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\Arthemida-2\API;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -169,6 +170,7 @@
     <ClInclude Include="..\..\Arthemida-2\ArtModules\MemoryScanner.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtModules\ModuleScanner.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtModules\HeuristicScanner.h" />
+    <ClInclude Include="..\..\Arthemida-2\ArtModules\ArtThreading.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtModules\ThreadScanner.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\CRC32.h" />
     <ClInclude Include="..\..\Arthemida-2\ArtUtils\MiniJumper.h" />

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj.filters
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ArtemisTerminal.vcxproj.filters
@@ -77,5 +77,8 @@
     <ClInclude Include="..\..\Arthemida-2\ArtModules\CServiceMon.h">
       <Filter>Arthemida-2\ArtModules</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Arthemida-2\ArtModules\ArtThreading.h">
+      <Filter>Arthemida-2\ArtModules</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/ArtemisComponents/ConsoleTests/ArtemisTerminal/ConsoleHost.cpp
+++ b/ArtemisComponents/ConsoleTests/ArtemisTerminal/ConsoleHost.cpp
@@ -72,6 +72,18 @@ void __stdcall ArthemidaCallback(ARTEMIS_DATA* artemis)
 		artemis->HackName.c_str(), artemis->filePath.c_str());
 		//"Path: %s | \nName: %s  | Description: %s | \nType: %d | BootSet: %s | Group: %s\n | Signed by: %s\n");
 		break;
+	case DetectionType::ART_MEMORY_PROTECT_VIOLATION:
+		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected memory protect violation!\nBase: 0x%X | Size: 0x%X\n\n",
+			(DWORD)artemis->baseAddr, (DWORD)artemis->regionSize);
+		break;
+	case DetectionType::ART_MEMORY_PROTECT_MAYBE_VIOLATION:
+		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected light memory protect violation!\nBase: 0x%X | Size: 0x%X\n\n",
+			(DWORD)artemis->baseAddr, (DWORD)artemis->regionSize);
+		break;
+	case DetectionType::ART_THREAD_FLAGS_CHANGED:
+		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Detected thread with modified flags!\nHandle: 0x%X",
+			(DWORD)artemis->baseAddr);
+		break;
 	default:
 		Utils::LogInFile(ARTEMIS_LOG, "[CALLBACK] Unknown detection code! Base: 0x%X | Size: %d bytes | DllName: %s\n"
 		"\rPath: %s\n\n", artemis->baseAddr, artemis->regionSize, artemis->dllName.c_str(), artemis->dllPath.c_str());
@@ -79,7 +91,7 @@ void __stdcall ArthemidaCallback(ARTEMIS_DATA* artemis)
 	}
 	Utils::LogInFile(ARTEMIS_LOG, "\n\n");
 }
-class RetTest
+/*class RetTest
 {
 public:
 	static bool __stdcall TestStaticMethod(void)
@@ -95,7 +107,7 @@ public:
 		if (art_interface != nullptr) art_interface->ConfirmLegitReturn(__FUNCTION__, _ReturnAddress());
 		Utils::LogInFile(ARTEMIS_LOG, "\n[ORIGINAL] Called %s!\n\n", __FUNCTION__);
 	}
-}; RetTest testObj;
+}; RetTest testObj;*/
 int main()
 {
 	SetConsoleCP(1251); SetConsoleOutputCP(1251);
@@ -111,15 +123,18 @@ int main()
 	cfg.DetectManualMap = true; 
 	cfg.MemoryScanDelay = 1000; 
 
-	//cfg.DetectMemoryPatch = true; 
-	//cfg.MemoryGuardScanDelay = 1000;
+	cfg.MemoryGuard = true; 
+	cfg.MemoryGuardScanDelay = 1;
+
+	cfg.ThreadGuard = true;
+	cfg.ThreadGuardDelay = 500;
 	//cfg.HooksList.insert(std::pair<PVOID, PVOID>((PVOID)RetTest::TestStaticMethod, (PVOID)HookTestStaticMethod));
 	// __thiscall methods must be casted in a different way
 	
 	cfg.ServiceMon = true;
 	cfg.ServiceMonDelay = 1000;
 	cfg.IllegalDriverPatterns.insert(CortPair("HWIDSYS spoofer", std::make_tuple
-	("\x5B\x64\x62\x67\x5D\x20\x72\x65\x76\x65\x72\x74\x65\x64\x20\x25\x77\x5A\x20\x73\x77\x61\x70", "xxxxxxxxxxxxxxxxxxxxxxx")));
+	("\x5B\x64\x62\x67\x5D\x20\x72\x65\x76\x65\x72\x74\x65\x64\x20\x25\x77\x5A\x20\x73\x77\x61\x70"s, "xxxxxxxxxxxxxxxxxxxxxxx"s)));
 	//todo cfg.PriorityDriverNames
 	//////////////////////////////// Heuristical Scanning ///////////////////////////////////////////
 	cfg.DetectPacking = true;
@@ -129,7 +144,7 @@ int main()
 	cfg.IlegaleLinien = Linien; // Add deprecated string from hacks here!
 	cfg.DetectBySignature = true; 
 	cfg.IllegalPatterns.insert(CortPair("HWBP by NtKernelMC", 
-	std::make_tuple("\x8D\x45\xF4\x64\xA3\x00\x00\x00\x00\x68", "xxxxxxxxxx")));
+	std::make_tuple("\x8D\x45\xF4\x64\xA3\x00\x00\x00\x00\x68"s, "xxxxxxxxxx"s)));
 	/////////////////////////////////////////////////////////////////////////////////////////////////
 	cfg.DetectFakeLaunch = true;
 	cfg.callback = (ArtemisCallback)ArthemidaCallback; 
@@ -139,7 +154,8 @@ int main()
 	for (;;) 
 	{
 		Sleep(3000); static bool first = false; if (!first) { first = true; printf("\n"); }
-		printf("\n[HEART-BEAT] Console is working normally! Thread ID: %d | Press any key to stop.\n\n", GetCurrentThreadId());
+		// ZAEBALO FLUDIT BLYAT
+		//printf("\n[HEART-BEAT] Console is working normally! Thread ID: %d | Press any key to stop.\n\n", GetCurrentThreadId());
 	} });
 
 	IArtemisInterface* art = IArtemisInterface::InstallArtemisMonitor(&cfg);


### PR DESCRIPTION
Финальные модули первого этапа.

* Bugfix - исправлен баг NtKernelMC с передачей сигнатур.

MemoryGuard - сканирование и превенция нелегальных прав (PAGE_EXECUTE_READWRITE), а также нелегальных изменений прав (с PAGE_READWRITE на PAGE_EXECUTE_*). Перехват вызовов VirtualProtect/VirtualProtectEx/NtProtectVirtualMemory и отклонение запросов на выдачу нелегальных прав или произведение нелегальных изменений. Смотрите TBD в главном комментарии файла для будущих улучшений.

ArtThreading - создание защищенных потоков с специальными незадокументированными флагами, которые предотвращают завершение или заморозку потоков (заморозка только Win10 19H1+). Смотрите TBD в главном комментарии файла для будущих улучшений.

ThreadGuard - сканнер защищенных потоков и их проверка на факт снятия специальных флагов (тех, которые возможно снять).

Примечание: для корректной работы всех модулей нужно убрать дефайн ARTEMIS_DEBUG, т.к. некоторые функции  ломают дебагер и мешают отладке, поэтому они были помещены под защиту этого дефайна.
Внимание: после выключения этого дефайна ни в коем случае не останавливать потоки вручную!